### PR TITLE
Allow users to inject a custom fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,35 @@ new ChalkClient({
    * If not specified and unset by your environment, an error will be thrown on client creation
    */
   activeEnvironment?: string;
+
+  /**
+   * Tracing options that will be forwarded to the OTLP Trace Exporter. Traces are exported using http.
+   * Traces can be exported to an OpenTelemetry collector and exported to any compatible tracing backend,
+   * or can be exported to any compatible tracing backend directly.
+   *
+   * `url:` URL to export OpenTelemetry traces to. Defaults to http://localhost:4318/v1/traces.
+   * If not specified, will use the environment variable _CHALK_TRACING_EXPORT_URL.
+   *
+   * `headers:` Headers to send with the trace http requests.
+   *
+   * `tracingActive:` Boolean that indicates whether to collect and export traces. Defaults to `false`.
+   * If not specified, will use the environment variable _CHALK_TRACING_ACTIVE.
+   */
+  tracingOptions?: TracingOptions;
+
+  /**
+   * A custom fetch client that will replace the fetch polyfill used by default.
+   *
+   * If not provided, the client will use the default fetch polyfill (native fetch with node-fetch as a fallback).
+   */
+  fetch?: CustomFetchClient;
+
+  /**
+   * A custom fetch headers object that will replace the fetch Headers polyfill used by default.
+   *
+   * If not provided, the client will use the default fetch Headers polyfill (native fetch with node-fetch as a fallback).
+   */
+  fetchHeaders?: typeof Headers;
 })
 ```
 
@@ -116,6 +145,8 @@ new ChalkClient({
 | `process.env._CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `clientSecret` value when constructing your ChalkClient |
 | `process.env._CHALK_ACTIVE_ENVIRONMENT` | Optional     | The environment that your client should connect to. If not specified, the client will query your project's default environment                   |
 | `process.env._CHALK_API_SERVER`         | Optional     | The API server that the client will communicate with. This defaults to https://api.chalk.ai which should be sufficient for most consumers        |
+| `process.env._CHALK_TRACING_EXPORT_URL` | Optional     | The url you would like your client to export OpenTelemetry traces to. This defaults to http://localhost:4318/v1/traces.                          |
+| `process.env._CHALK_TRACING_ACTIVE`     | Optional     | Boolean indicating whether the client should collect and export trace data. This defaults to `false`                                             |
 
 You can find relevant variables to use with your Chalk Client by
 running `chalk config` with the Chalk command line tool.

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -5,6 +5,14 @@ export interface ChalkClientConfig {
   activeEnvironment: string | undefined;
 }
 
+export interface CustomFetchClient<
+  Req = RequestInfo | URL,
+  ReqInit = RequestInit,
+  Resp = Response
+> {
+  (input: Req, init?: ReqInit | undefined): Promise<Resp>;
+}
+
 export interface ChalkEnvironmentVariables {
   _CHALK_CLIENT_ID: string;
   _CHALK_CLIENT_SECRET: string;


### PR DESCRIPTION
The client uses a polyfill that defaults to native fetch and falls back to `node-fetch`. This means that if it is run under a Node version that provides a native fetch, it will use that. However, some users may want to provide their own fetch implementation. This change adds `fetch` and `fetchHeaders` fields to the client config object that will replace the default polyfilled `fetch` and `Headers`.