### PR TITLE
Update queryBulk input type

### DIFF
--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -127,7 +127,7 @@ maybe("integration tests", () => {
     it("query_bulk fraud template", async () => {
       const result = await client.queryBulk({
         inputs: {
-          "user.id": [1, 2] as any,
+          "user.id": [1, 2],
         },
         outputs: ["user.id", "user.full_name"],
         encodingOptions: {

--- a/src/_interface.ts
+++ b/src/_interface.ts
@@ -57,7 +57,7 @@ export interface ChalkOnlineBulkQueryRequest<
   TFeatureMap,
   TOutput extends keyof TFeatureMap
 > {
-  inputs: Partial<TFeatureMap>;
+  inputs: Partial<{ [K in keyof TFeatureMap]: TFeatureMap[K][] }>;
   outputs: TOutput[];
   staleness?: {
     [K in keyof TFeatureMap]?: string;


### PR DESCRIPTION
The `queryBulk` method takes an array of values for each input instead of a single value. This change updates the type annotation to accurately reflect this.