### PR TITLE
New Option to Allow Timestamp Formatting between EPOCH_MILLIS and ISO_8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ new ChalkClient({
   clientId?: string;
 
   /**
-   * Your Chalk Client Secret. This value will be read from the _CHALK_CLIENT_ID environment variable if not set explicitly.
+   * Your Chalk Client Secret. This value will be read from the _CHALK_CLIENT_SECRET environment variable if not set explicitly.
    *
    * If not specified and unset by your environment, an error will be thrown on client creation
    */

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ new ChalkClient({
    * If not provided, the client will use the default fetch Headers polyfill (native fetch with node-fetch as a fallback).
    */
   fetchHeaders?: typeof Headers;
+
+  /**
+   * The format to use for date-type data.
+   *
+   * Defaults to "ISO_8601" (in UTC), also supports "EPOCH_MILLIS" as number of milliseconds since epoch
+   */
+  timestampFormat?: TimestampFormat.ISO_8601 | TimestampFormat.EPOCH_MILLIS;
 })
 ```
 

--- a/src/__test__/client.test.ts
+++ b/src/__test__/client.test.ts
@@ -35,6 +35,7 @@ describe("ChalkClient", () => {
       apiServer: "b",
       clientId: "c",
       clientSecret: "d",
+      timestampFormat: "EPOCH_MILLIS",
     });
 
     expect(getConfig(client)).toEqual<ChalkClientConfig>({
@@ -43,6 +44,7 @@ describe("ChalkClient", () => {
       clientId: "c",
       clientSecret: "d",
       queryServer: "b",
+      timestampFormat: "EPOCH_MILLIS",
     });
   });
 
@@ -61,6 +63,7 @@ describe("ChalkClient", () => {
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: "http://localhost:1337",
+      timestampFormat: "ISO_8601",
     });
   });
 
@@ -83,6 +86,7 @@ describe("ChalkClient", () => {
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: DEFAULT_API_SERVER,
+      timestampFormat: "ISO_8601",
     });
   });
 
@@ -97,6 +101,7 @@ describe("ChalkClient", () => {
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: "query server",
+      timestampFormat: "ISO_8601",
     });
   });
 

--- a/src/__test__/client.test.ts
+++ b/src/__test__/client.test.ts
@@ -1,6 +1,6 @@
 import { ChalkClient } from "../_client";
 import { DEFAULT_API_SERVER } from "../_const";
-import { ChalkClientConfig } from "../_types";
+import { ChalkClientConfig, TimestampFormat } from "../_types";
 
 function getConfig(client: ChalkClient): ChalkClientConfig {
   return (client as any).config;
@@ -35,7 +35,7 @@ describe("ChalkClient", () => {
       apiServer: "b",
       clientId: "c",
       clientSecret: "d",
-      timestampFormat: "EPOCH_MILLIS",
+      timestampFormat: TimestampFormat.EPOCH_MILLIS,
     });
 
     expect(getConfig(client)).toEqual<ChalkClientConfig>({
@@ -44,7 +44,7 @@ describe("ChalkClient", () => {
       clientId: "c",
       clientSecret: "d",
       queryServer: "b",
-      timestampFormat: "EPOCH_MILLIS",
+      timestampFormat: TimestampFormat.EPOCH_MILLIS,
     });
   });
 
@@ -63,7 +63,7 @@ describe("ChalkClient", () => {
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: "http://localhost:1337",
-      timestampFormat: "ISO_8601",
+      timestampFormat: TimestampFormat.ISO_8601,
     });
   });
 
@@ -86,7 +86,7 @@ describe("ChalkClient", () => {
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: DEFAULT_API_SERVER,
-      timestampFormat: "ISO_8601",
+      timestampFormat: TimestampFormat.ISO_8601,
     });
   });
 
@@ -101,7 +101,7 @@ describe("ChalkClient", () => {
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: "query server",
-      timestampFormat: "ISO_8601",
+      timestampFormat: TimestampFormat.ISO_8601,
     });
   });
 

--- a/src/__test__/client.test.ts
+++ b/src/__test__/client.test.ts
@@ -1,6 +1,7 @@
 import { ChalkClient } from "../_client";
 import { DEFAULT_API_SERVER } from "../_const";
-import { ChalkClientConfig, TimestampFormat } from "../_types";
+import { ChalkClientConfig } from "../_types";
+import { TimestampFormat } from "../_interface";
 
 function getConfig(client: ChalkClient): ChalkClientConfig {
   return (client as any).config;

--- a/src/__test__/deserialization.test.ts
+++ b/src/__test__/deserialization.test.ts
@@ -22,12 +22,15 @@ describe("parseByteModel", () => {
   });
 });
 
-function _parseByteDataToJSON(filename: string) {
+function _parseByteDataToJSON(
+  filename: string,
+  timestampFormat: TimestampFormat = TimestampFormat.ISO_8601
+) {
   const byte_data = fs.readFileSync(path.resolve(__dirname, filename));
   return JSON.parse(
     JSON.stringify(
       parseFeatherQueryResponse(byte_data, {
-        timestampFormat: TimestampFormat.ISO_8601,
+        timestampFormat,
       })
     )
   );

--- a/src/__test__/deserialization.test.ts
+++ b/src/__test__/deserialization.test.ts
@@ -23,7 +23,11 @@ describe("parseByteModel", () => {
 
 function _parseByteDataToJSON(filename: string) {
   const byte_data = fs.readFileSync(path.resolve(__dirname, filename));
-  return JSON.parse(JSON.stringify(parseFeatherQueryResponse(byte_data)));
+  return JSON.parse(
+    JSON.stringify(
+      parseFeatherQueryResponse(byte_data, { timestampFormat: "ISO_8601" })
+    )
+  );
 }
 
 function _readJson(filename: string) {
@@ -65,7 +69,9 @@ describe("parseFeatherQueryResponse", () => {
     );
 
     const tryToParseCompressed = () =>
-      parseFeatherQueryResponse(single_bytes_compressed);
+      parseFeatherQueryResponse(single_bytes_compressed, {
+        timestampFormat: "ISO_8601",
+      });
 
     expect(tryToParseCompressed).toThrow(
       "Record batch compression not implemented"

--- a/src/__test__/deserialization.test.ts
+++ b/src/__test__/deserialization.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { parseByteModel, parseFeatherQueryResponse } from "../_bulk_response";
-import { TimestampFormat } from "../_types";
+import { TimestampFormat } from "../_interface";
 
 describe("parseByteModel", () => {
   it("should produce the expected keys", () => {
@@ -46,6 +46,15 @@ describe("parseFeatherQueryResponse", () => {
   it("should handle a multi-query feather response", () => {
     const bytes = _parseByteDataToJSON("binaries/uncompressed_multi.bytes");
     const json = _readJson("json/uncompressed_multi.json");
+    expect(bytes).toMatchObject(json);
+  });
+
+  it("should handle a feather response with epoch_millis timestamp option passed in", () => {
+    const bytes = _parseByteDataToJSON(
+      "binaries/uncompressed_multi.bytes",
+      TimestampFormat.EPOCH_MILLIS
+    );
+    const json = _readJson("json/uncompressed_multi_epoch_millis.json");
     expect(bytes).toMatchObject(json);
   });
 

--- a/src/__test__/deserialization.test.ts
+++ b/src/__test__/deserialization.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { parseByteModel, parseFeatherQueryResponse } from "../_bulk_response";
+import { TimestampFormat } from "../_types";
 
 describe("parseByteModel", () => {
   it("should produce the expected keys", () => {
@@ -25,7 +26,9 @@ function _parseByteDataToJSON(filename: string) {
   const byte_data = fs.readFileSync(path.resolve(__dirname, filename));
   return JSON.parse(
     JSON.stringify(
-      parseFeatherQueryResponse(byte_data, { timestampFormat: "ISO_8601" })
+      parseFeatherQueryResponse(byte_data, {
+        timestampFormat: TimestampFormat.ISO_8601,
+      })
     )
   );
 }
@@ -70,7 +73,7 @@ describe("parseFeatherQueryResponse", () => {
 
     const tryToParseCompressed = () =>
       parseFeatherQueryResponse(single_bytes_compressed, {
-        timestampFormat: "ISO_8601",
+        timestampFormat: TimestampFormat.ISO_8601,
       });
 
     expect(tryToParseCompressed).toThrow(

--- a/src/__test__/json/uncompressed_multi.json
+++ b/src/__test__/json/uncompressed_multi.json
@@ -5,29 +5,29 @@
         "user.random_normal": -2.504300832748413,
         "user.full_name": "Donna Davis",
         "user.id": 1,
-        "user.__chalk_observed_at__": 1712708210149.395,
-        "__ts__": 1712708210149.395
+        "user.__chalk_observed_at__": "2024-04-10T00:16:50.149Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       },
       {
         "user.random_normal": -1.4988536834716797,
         "user.full_name": "William Johnson",
         "user.id": 2,
-        "user.__chalk_observed_at__": 1712708210149.395,
-        "__ts__": 1712708210149.395
+        "user.__chalk_observed_at__": "2024-04-10T00:16:50.149Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       },
       {
         "user.random_normal": 1.758903980255127,
         "user.full_name": "Jasmine Perry",
         "user.id": 3,
-        "user.__chalk_observed_at__": 1712708210149.395,
-        "__ts__": 1712708210149.395
+        "user.__chalk_observed_at__": "2024-04-10T00:16:50.149Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       },
       {
         "user.random_normal": 1.3693839311599731,
         "user.full_name": "Matthew Roth",
         "user.id": 4,
-        "user.__chalk_observed_at__": 1712708210149.395,
-        "__ts__": 1712708210149.395
+        "user.__chalk_observed_at__": "2024-04-10T00:16:50.149Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       }
     ],
     "meta": {
@@ -47,29 +47,29 @@
         "transaction.amount": 623,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 1,
-        "transaction.ts": 1675322153833.177,
-        "__ts__": 1712708210149.395
+        "transaction.ts": "2023-02-02T07:15:53.833Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       },
       {
         "transaction.amount": 597,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 2,
-        "transaction.ts": 1674313291406.393,
-        "__ts__": 1712708210149.395
+        "transaction.ts": "2023-01-21T15:01:31.406Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       },
       {
         "transaction.amount": 514,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 3,
-        "transaction.ts": 1675490035989.8472,
-        "__ts__": 1712708210149.395
+        "transaction.ts": "2023-02-04T05:53:55.989Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       },
       {
         "transaction.amount": 902,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 4,
-        "transaction.ts": 1677039917026.701,
-        "__ts__": 1712708210149.395
+        "transaction.ts": "2023-02-22T04:25:17.026Z",
+        "__ts__": "2024-04-10T00:16:50.149Z"
       }
     ],
     "meta": {

--- a/src/__test__/json/uncompressed_multi_epoch_millis.json
+++ b/src/__test__/json/uncompressed_multi_epoch_millis.json
@@ -1,0 +1,86 @@
+[
+  {
+    "data": [
+      {
+        "user.random_normal": -2.504300832748413,
+        "user.full_name": "Donna Davis",
+        "user.id": 1,
+        "user.__chalk_observed_at__": 1712708210149.395,
+        "__ts__": 1712708210149.395
+      },
+      {
+        "user.random_normal": -1.4988536834716797,
+        "user.full_name": "William Johnson",
+        "user.id": 2,
+        "user.__chalk_observed_at__": 1712708210149.395,
+        "__ts__": 1712708210149.395
+      },
+      {
+        "user.random_normal": 1.758903980255127,
+        "user.full_name": "Jasmine Perry",
+        "user.id": 3,
+        "user.__chalk_observed_at__": 1712708210149.395,
+        "__ts__": 1712708210149.395
+      },
+      {
+        "user.random_normal": 1.3693839311599731,
+        "user.full_name": "Matthew Roth",
+        "user.id": 4,
+        "user.__chalk_observed_at__": 1712708210149.395,
+        "__ts__": 1712708210149.395
+      }
+    ],
+    "meta": {
+      "executionDurationS": 0.84107918899997,
+      "deploymentId": "clusuova000050ms659jbbklg",
+      "environmentId": "tmnmwqtcbscbd",
+      "environmentName": "dev",
+      "queryId": "clut28wrt00110js6ygjq3lh4",
+      "queryTimestamp": "2024-04-10T00:16:50.149395+00:00",
+      "queryHash": "354c5201ef4248bbc78810f4d987d506d5fa3b98ee2579b7f715896a96e080e5",
+      "explainOutput": null
+    }
+  },
+  {
+    "data": [
+      {
+        "transaction.amount": 623,
+        "transaction.user.full_name": "Norma Fisher",
+        "transaction.id": 1,
+        "transaction.ts": 1675322153833.177,
+        "__ts__": 1712708210149.395
+      },
+      {
+        "transaction.amount": 597,
+        "transaction.user.full_name": "Norma Fisher",
+        "transaction.id": 2,
+        "transaction.ts": 1674313291406.393,
+        "__ts__": 1712708210149.395
+      },
+      {
+        "transaction.amount": 514,
+        "transaction.user.full_name": "Norma Fisher",
+        "transaction.id": 3,
+        "transaction.ts": 1675490035989.8472,
+        "__ts__": 1712708210149.395
+      },
+      {
+        "transaction.amount": 902,
+        "transaction.user.full_name": "Norma Fisher",
+        "transaction.id": 4,
+        "transaction.ts": 1677039917026.701,
+        "__ts__": 1712708210149.395
+      }
+    ],
+    "meta": {
+      "executionDurationS": 1.2813234230000035,
+      "deploymentId": "clusuova000050ms659jbbklg",
+      "environmentId": "tmnmwqtcbscbd",
+      "environmentName": "dev",
+      "queryId": "clut28ws200120js64ydzykju",
+      "queryTimestamp": "2024-04-10T00:16:50.149395+00:00",
+      "queryHash": "38c05bd2ead10b4c8a11d00e8e2df128952eec32ed073e53ff83980259f2308d",
+      "explainOutput": null
+    }
+  }
+]

--- a/src/__test__/json/uncompressed_multi_error.json
+++ b/src/__test__/json/uncompressed_multi_error.json
@@ -5,29 +5,29 @@
         "user.random_normal": -0.6867642402648926,
         "user.full_name": "Donna Davis",
         "user.id": 1,
-        "user.__chalk_observed_at__": 1712708226312.231,
-        "__ts__": 1712708226312.231
+        "user.__chalk_observed_at__": "2024-04-10T00:17:06.312Z",
+        "__ts__": "2024-04-10T00:17:06.312Z"
       },
       {
         "user.random_normal": -1.0890105962753296,
         "user.full_name": "William Johnson",
         "user.id": 2,
-        "user.__chalk_observed_at__": 1712708226312.231,
-        "__ts__": 1712708226312.231
+        "user.__chalk_observed_at__": "2024-04-10T00:17:06.312Z",
+        "__ts__": "2024-04-10T00:17:06.312Z"
       },
       {
         "user.random_normal": -0.18598082661628723,
         "user.full_name": "Jasmine Perry",
         "user.id": 3,
-        "user.__chalk_observed_at__": 1712708226312.231,
-        "__ts__": 1712708226312.231
+        "user.__chalk_observed_at__": "2024-04-10T00:17:06.312Z",
+        "__ts__": "2024-04-10T00:17:06.312Z"
       },
       {
         "user.random_normal": -0.10236824303865433,
         "user.full_name": "Matthew Roth",
         "user.id": 4,
-        "user.__chalk_observed_at__": 1712708226312.231,
-        "__ts__": 1712708226312.231
+        "user.__chalk_observed_at__": "2024-04-10T00:17:06.312Z",
+        "__ts__": "2024-04-10T00:17:06.312Z"
       }
     ],
     "meta": {

--- a/src/__test__/json/uncompressed_single.json
+++ b/src/__test__/json/uncompressed_single.json
@@ -5,29 +5,29 @@
         "user.random_normal": 2.376134157180786,
         "user.full_name": "Donna Davis",
         "user.id": 1,
-        "user.__chalk_observed_at__": 1712708264809.198,
-        "__ts__": 1712708264809.198
+        "user.__chalk_observed_at__": "2024-04-10T00:17:44.809Z",
+        "__ts__": "2024-04-10T00:17:44.809Z"
       },
       {
         "user.random_normal": -1.5992772579193115,
         "user.full_name": "William Johnson",
         "user.id": 2,
-        "user.__chalk_observed_at__": 1712708264809.198,
-        "__ts__": 1712708264809.198
+        "user.__chalk_observed_at__": "2024-04-10T00:17:44.809Z",
+        "__ts__": "2024-04-10T00:17:44.809Z"
       },
       {
         "user.random_normal": -0.29425880312919617,
         "user.full_name": "Jasmine Perry",
         "user.id": 3,
-        "user.__chalk_observed_at__": 1712708264809.198,
-        "__ts__": 1712708264809.198
+        "user.__chalk_observed_at__": "2024-04-10T00:17:44.809Z",
+        "__ts__": "2024-04-10T00:17:44.809Z"
       },
       {
         "user.random_normal": -0.15812711417675018,
         "user.full_name": "Matthew Roth",
         "user.id": 4,
-        "user.__chalk_observed_at__": 1712708264809.198,
-        "__ts__": 1712708264809.198
+        "user.__chalk_observed_at__": "2024-04-10T00:17:44.809Z",
+        "__ts__": "2024-04-10T00:17:44.809Z"
       }
     ],
     "meta": {

--- a/src/__test__/json/uncompressed_triple.json
+++ b/src/__test__/json/uncompressed_triple.json
@@ -5,29 +5,29 @@
         "user.random_normal": 0.20071464776992798,
         "user.full_name": "Donna Davis",
         "user.id": 1,
-        "user.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "user.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "user.random_normal": 1.5254939794540405,
         "user.full_name": "William Johnson",
         "user.id": 2,
-        "user.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "user.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "user.random_normal": 0.30414295196533203,
         "user.full_name": "Jasmine Perry",
         "user.id": 3,
-        "user.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "user.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "user.random_normal": -0.2956961393356323,
         "user.full_name": "Matthew Roth",
         "user.id": 4,
-        "user.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "user.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       }
     ],
     "meta": {
@@ -47,29 +47,29 @@
         "transaction.amount": 623,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 1,
-        "transaction.ts": 1675322153833.177,
-        "__ts__": 1712708962424.895
+        "transaction.ts": "2023-02-02T07:15:53.833Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "transaction.amount": 597,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 2,
-        "transaction.ts": 1674313291406.393,
-        "__ts__": 1712708962424.895
+        "transaction.ts": "2023-01-21T15:01:31.406Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "transaction.amount": 514,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 3,
-        "transaction.ts": 1675490035989.8472,
-        "__ts__": 1712708962424.895
+        "transaction.ts": "2023-02-04T05:53:55.989Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "transaction.amount": 902,
         "transaction.user.full_name": "Norma Fisher",
         "transaction.id": 4,
-        "transaction.ts": 1677039917026.701,
-        "__ts__": 1712708962424.895
+        "transaction.ts": "2023-02-22T04:25:17.026Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       }
     ],
     "meta": {
@@ -89,43 +89,43 @@
         "bag_of_stuff.f1": "f1",
         "bag_of_stuff.f2": "f2",
         "bag_of_stuff.id": 1,
-        "bag_of_stuff.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "bag_of_stuff.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "bag_of_stuff.f1": "f1",
         "bag_of_stuff.f2": "f2",
         "bag_of_stuff.id": 2,
-        "bag_of_stuff.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "bag_of_stuff.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "bag_of_stuff.f1": "f1",
         "bag_of_stuff.f2": "f2",
         "bag_of_stuff.id": 3,
-        "bag_of_stuff.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "bag_of_stuff.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "bag_of_stuff.f1": "f1",
         "bag_of_stuff.f2": "f2",
         "bag_of_stuff.id": 4,
-        "bag_of_stuff.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "bag_of_stuff.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "bag_of_stuff.f1": "f1",
         "bag_of_stuff.f2": "f2",
         "bag_of_stuff.id": 5,
-        "bag_of_stuff.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "bag_of_stuff.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       },
       {
         "bag_of_stuff.f1": "f1",
         "bag_of_stuff.f2": "f2",
         "bag_of_stuff.id": 6,
-        "bag_of_stuff.__chalk_observed_at__": 1712708962424.895,
-        "__ts__": 1712708962424.895
+        "bag_of_stuff.__chalk_observed_at__": "2024-04-10T00:29:22.424Z",
+        "__ts__": "2024-04-10T00:29:22.424Z"
       }
     ],
     "meta": {

--- a/src/_bulk_response.ts
+++ b/src/_bulk_response.ts
@@ -9,9 +9,9 @@ import {
   TimeUnit,
 } from "apache-arrow";
 import { RawQueryResponseMeta } from "./_http";
-import { ChalkError, ChalkQueryMeta } from "./_interface";
+import { ChalkError, ChalkQueryMeta, TimestampFormat } from "./_interface";
 import { mapRawResponseMeta } from "./_meta";
-import { ChalkClientConfig, TimestampFormat } from "./_types";
+import { ChalkClientConfig } from "./_types";
 
 interface ByteModel {
   attrs: { [key: string]: number | string } & {

--- a/src/_bulk_response.ts
+++ b/src/_bulk_response.ts
@@ -11,7 +11,7 @@ import {
 import { RawQueryResponseMeta } from "./_http";
 import { ChalkError, ChalkQueryMeta } from "./_interface";
 import { mapRawResponseMeta } from "./_meta";
-import { ChalkClientConfig } from "./_types";
+import { ChalkClientConfig, TimestampFormat } from "./_types";
 
 interface ByteModel {
   attrs: { [key: string]: number | string } & {
@@ -124,14 +124,17 @@ export function processArrowTable(
       continue;
     }
 
-    if (timestampFormat === "ISO_8601" && DataType.isTimestamp(vector.type)) {
+    if (
+      timestampFormat === TimestampFormat.ISO_8601 &&
+      DataType.isTimestamp(vector.type)
+    ) {
       const newVector = vectorFromArray<Date_>(
         Array.from(vector, (data) => new Date(data)),
         new Date_(DateUnit.MILLISECOND)
       );
       newTable = newTable.setChildAt(index, newVector);
     } else if (
-      timestampFormat == "EPOCH_MILLIS" &&
+      timestampFormat == TimestampFormat.EPOCH_MILLIS &&
       DataType.isDate(vector.type)
     ) {
       const newVector = vectorFromArray<Timestamp>(

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -217,7 +217,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       timeout: requestOptions?.timeout,
     });
 
-    return parseOnlineQueryResponse(rawResult);
+    return parseOnlineQueryResponse(rawResult, this.config);
   }
 
   async multiQuery<TOutput extends keyof TFeatureMap>(

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -79,7 +79,7 @@ export interface ChalkClientOpts {
   /**
    * The format to use for date-type data.
    *
-   * Defaults to "ISO_8601" (in UTC), also supports "EPOCH_MILLIS"
+   * Defaults to "ISO_8601" (in UTC), also supports "EPOCH_MILLIS" as number of milliseconds since epoch
    */
   timestampFormat?: ChalkClientConfig["timestampFormat"];
 

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -218,7 +218,10 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       timeout: requestOptions?.timeout,
     });
 
-    return parseOnlineQueryResponse(rawResult, this.config);
+    return parseOnlineQueryResponse<TFeatureMap, TOutput>(
+      rawResult,
+      this.config
+    );
   }
 
   async multiQuery<TOutput extends keyof TFeatureMap>(

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -19,13 +19,13 @@ import {
   ChalkTriggerResolverRunResponse,
   ChalkUploadSingleRequest,
   ChalkWhoamiResponse,
+  TimestampFormat,
 } from "./_interface";
 import {
   ChalkClientConfig,
   ChalkEnvironmentVariables,
   ChalkScalar,
   CustomFetchClient,
-  TimestampFormat,
 } from "./_types";
 import { parseOnlineQueryResponse } from "./_response";
 
@@ -145,7 +145,11 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       timestampFormat: opts?.timestampFormat ?? TimestampFormat.ISO_8601,
     };
 
-    this.http = new ChalkHTTPService(opts?.fetch, opts?.fetchHeaders, opts?.defaultTimeout);
+    this.http = new ChalkHTTPService(
+      opts?.fetch,
+      opts?.fetchHeaders,
+      opts?.defaultTimeout
+    );
 
     this.credentials = new CredentialsHolder(this.config, this.http);
   }

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -25,6 +25,7 @@ import {
   ChalkEnvironmentVariables,
   ChalkScalar,
   CustomFetchClient,
+  TimestampFormat,
 } from "./_types";
 import { parseOnlineQueryResponse } from "./_response";
 
@@ -141,7 +142,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
         "_CHALK_CLIENT_SECRET"
       ),
       queryServer,
-      timestampFormat: opts?.timestampFormat ?? "ISO_8601",
+      timestampFormat: opts?.timestampFormat ?? TimestampFormat.ISO_8601,
     };
 
     this.http = new ChalkHTTPService(

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -145,11 +145,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       timestampFormat: opts?.timestampFormat ?? TimestampFormat.ISO_8601,
     };
 
-    this.http = new ChalkHTTPService(
-      opts?.fetch,
-      opts?.fetchHeaders,
-      opts?.defaultTimeout
-    );
+    this.http = new ChalkHTTPService(opts?.fetch, opts?.fetchHeaders, opts?.defaultTimeout);
 
     this.credentials = new CredentialsHolder(this.config, this.http);
   }

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -76,6 +76,13 @@ export interface ChalkClientOpts {
    */
   fetchHeaders?: typeof Headers;
 
+  /**
+   * The format to use for date-type data.
+   *
+   * Defaults to "ISO_8601" (in UTC), also supports "EPOCH_MILLIS"
+   */
+  timestampFormat?: ChalkClientConfig["timestampFormat"];
+
   defaultTimeout?: number;
 }
 
@@ -135,7 +142,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
         "_CHALK_CLIENT_SECRET"
       ),
       queryServer,
-      timestampFormat: opts?.time,
+      timestampFormat: opts?.timestampFormat ?? "ISO_8601",
     };
 
     this.http = new ChalkHTTPService(
@@ -274,7 +281,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     });
 
     const resultBuffer = Buffer.from(rawResult);
-    const parsedResult = parseFeatherQueryResponse(resultBuffer);
+    const parsedResult = parseFeatherQueryResponse(resultBuffer, this.config);
 
     return {
       responses: parsedResult,
@@ -310,7 +317,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     });
 
     const resultBuffer = Buffer.from(rawResult);
-    const parsedResult = parseFeatherQueryResponse(resultBuffer);
+    const parsedResult = parseFeatherQueryResponse(resultBuffer, this.config);
     const firstAndOnlyChunk = parsedResult[0];
 
     return firstAndOnlyChunk;

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -38,7 +38,7 @@ export interface ChalkClientOpts {
   clientId?: string;
 
   /**
-   * Your Chalk Client Secret. This value will be read from the _CHALK_CLIENT_ID environment variable if not set explicitly.
+   * Your Chalk Client Secret. This value will be read from the _CHALK_CLIENT_SECRET environment variable if not set explicitly.
    *
    * If not specified and unset by your environment, an error will be thrown on client creation
    */
@@ -99,11 +99,11 @@ function valueWithEnvFallback(
 }
 
 export interface ChalkRequestOptions {
-    /**
-     * The timeout for the request in milliseconds. If not provided, the client will use the default timeout
-     * specified at the client level.
-     */
-    timeout?: number;
+  /**
+   * The timeout for the request in milliseconds. If not provided, the client will use the default timeout
+   * specified at the client level.
+   */
+  timeout?: number;
 }
 
 export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
@@ -123,21 +123,26 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
         opts?.activeEnvironment ??
         process.env._CHALK_ACTIVE_ENVIRONMENT ??
         undefined,
-      clientSecret: valueWithEnvFallback(
-        "clientSecret",
-        opts?.clientSecret,
-        "_CHALK_CLIENT_SECRET"
-      ),
       apiServer: resolvedApiServer,
-      queryServer,
       clientId: valueWithEnvFallback(
         "clientId",
         opts?.clientId,
         "_CHALK_CLIENT_ID"
       ),
+      clientSecret: valueWithEnvFallback(
+        "clientSecret",
+        opts?.clientSecret,
+        "_CHALK_CLIENT_SECRET"
+      ),
+      queryServer,
+      timestampFormat: opts?.time,
     };
 
-    this.http = new ChalkHTTPService(opts?.fetch, opts?.fetchHeaders, opts?.defaultTimeout);
+    this.http = new ChalkHTTPService(
+      opts?.fetch,
+      opts?.fetchHeaders,
+      opts?.defaultTimeout
+    );
 
     this.credentials = new CredentialsHolder(this.config, this.http);
   }
@@ -203,7 +208,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       },
       headers: this.getDefaultHeaders(),
       credentials: this.credentials,
-      timeout: requestOptions?.timeout
+      timeout: requestOptions?.timeout,
     });
 
     // Alias the map values, so that TypeScript can help us construct the response.
@@ -238,7 +243,8 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   }
 
   async multiQuery<TOutput extends keyof TFeatureMap>(
-    request: ChalkOnlineMultiQueryRequest<TFeatureMap, TOutput>, requestOptions?: ChalkRequestOptions
+    request: ChalkOnlineMultiQueryRequest<TFeatureMap, TOutput>,
+    requestOptions?: ChalkRequestOptions
   ): Promise<ChalkOnlineMultiQueryResponse<TFeatureMap, TOutput>> {
     const requests = request.queries.map(
       (singleQuery): IntermediateRequestBodyJSON<TFeatureMap, TOutput> => {
@@ -264,7 +270,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       body: requestBuffer.buffer,
       headers: this.getDefaultHeaders(),
       credentials: this.credentials,
-      timeout: requestOptions?.timeout
+      timeout: requestOptions?.timeout,
     });
 
     const resultBuffer = Buffer.from(rawResult);
@@ -300,7 +306,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       body: requestBuffer.buffer,
       headers: this.getDefaultHeaders(),
       credentials: this.credentials,
-      timeout: requestOptions?.timeout
+      timeout: requestOptions?.timeout,
     });
 
     const resultBuffer = Buffer.from(rawResult);

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -76,6 +76,22 @@ export interface RawQueryResponseMeta {
   explain_output?: string;
 }
 
+type InternalPrimitiveType =
+  | "str"
+  | "int"
+  | "float"
+  | "bool"
+  | "datetime.date"
+  | "datetime.datetime"
+  | "datetime.time"
+  | "datetime.timedelta";
+
+export type ChalkPrimitiveType = `<class '${InternalPrimitiveType}'>`;
+export const CHALK_DATE_TYPES: Set<ChalkPrimitiveType> = new Set([
+  `<class 'datetime.date'>`,
+  `<class 'datetime.datetime'>`,
+]);
+
 const APPLICATION_JSON = "application/json;charset=utf-8";
 const APPLICATION_OCTET = "application/octet-stream";
 
@@ -143,12 +159,34 @@ interface ChalkErrorData {
   resolver?: string;
 }
 
+export interface ChalkOnlineQueryRawResponse {
+  data: {
+    field: string;
+    value: any;
+    pkey?: null | string | number;
+    error?: ChalkErrorData;
+    ts?: string;
+    meta?: {
+      chosen_resolver_fqn?: string;
+      cache_hit?: boolean;
+      primitive_type?: ChalkPrimitiveType;
+      version?: number;
+    };
+  }[];
+  errors?: ChalkErrorData[];
+  meta?: RawQueryResponseMeta;
+}
+
 export class ChalkHTTPService {
   private fetchClient: CustomFetchClient;
   private fetchHeaders: typeof Headers;
   private defaultTimeout: number | undefined;
 
-  constructor(fetchClient?: CustomFetchClient, fetchHeaders?: typeof Headers, defaultTimeout?: number) {
+  constructor(
+    fetchClient?: CustomFetchClient,
+    fetchHeaders?: typeof Headers,
+    defaultTimeout?: number
+  ) {
     this.fetchClient = fetchClient ?? (isoFetch as any); // cast for any's editor
     this.fetchHeaders = fetchHeaders ?? isoHeaders;
     this.defaultTimeout = defaultTimeout;
@@ -197,7 +235,7 @@ export class ChalkHTTPService {
       const effectiveTimeout = callArgs.timeout ?? this.defaultTimeout;
 
       if (effectiveTimeout != null) {
-          headers.set("X-Chalk-Timeout", effectiveTimeout.toString());
+        headers.set("X-Chalk-Timeout", effectiveTimeout.toString());
       }
 
       const body =
@@ -207,36 +245,40 @@ export class ChalkHTTPService {
             : callArgs.body
           : undefined;
 
-
       try {
-          const result = await this.fetchClient(
-              urlJoin(callArgs.baseUrl, opts.path),
-              {
-                  method: opts.method,
-                  headers,
-                  body: body as any,
-                  signal: effectiveTimeout != null ? AbortSignal.timeout(effectiveTimeout) : undefined
-              }
-          );
-          if (result.status < 200 || result.status >= 300) {
-            const errorText = await result.text();
-            throw new ChalkError(errorText, {
-              httpStatus: result.status,
-              httpStatusText: result.statusText,
-            });
+        const result = await this.fetchClient(
+          urlJoin(callArgs.baseUrl, opts.path),
+          {
+            method: opts.method,
+            headers,
+            body: body as any,
+            signal:
+              effectiveTimeout != null
+                ? AbortSignal.timeout(effectiveTimeout)
+                : undefined,
           }
+        );
+        if (result.status < 200 || result.status >= 300) {
+          const errorText = await result.text();
+          throw new ChalkError(errorText, {
+            httpStatus: result.status,
+            httpStatusText: result.statusText,
+          });
+        }
 
-          if (opts.binaryResponseBody) {
-            return result.arrayBuffer() as any;
-          } else {
-            return result.json() as any as TResponseBody;
-          }
+        if (opts.binaryResponseBody) {
+          return result.arrayBuffer() as any;
+        } else {
+          return result.json() as any as TResponseBody;
+        }
       } catch (e) {
-          if (e instanceof DOMException) {
-              throw chalkError("Request timed out after " + effectiveTimeout + "ms");
-          } else {
-              throw e;
-          }
+        if (e instanceof DOMException) {
+          throw chalkError(
+            "Request timed out after " + effectiveTimeout + "ms"
+          );
+        } else {
+          throw e;
+        }
       }
     };
 
@@ -322,23 +364,7 @@ export class ChalkHTTPService {
       include_meta: boolean;
       planner_options?: { [index: string]: string | boolean | number };
     },
-    responseBody: null! as {
-      data: {
-        field: string;
-        value: any;
-        pkey?: null | string | number;
-        error?: ChalkErrorData;
-        ts?: string;
-        meta?: {
-          chosen_resolver_fqn?: string;
-          cache_hit?: boolean;
-          primitive_type?: string;
-          version?: number;
-        };
-      }[];
-      errors?: ChalkErrorData[];
-      meta?: RawQueryResponseMeta;
-    },
+    responseBody: null! as ChalkOnlineQueryRawResponse,
   });
 
   public v1_query_feather = this.createEndpoint({

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -87,10 +87,8 @@ type InternalPrimitiveType =
   | "datetime.timedelta";
 
 export type ChalkPrimitiveType = `<class '${InternalPrimitiveType}'>`;
-export const CHALK_DATE_TYPES: Set<ChalkPrimitiveType> = new Set([
-  `<class 'datetime.date'>`,
-  `<class 'datetime.datetime'>`,
-]);
+export const CHALK_DATE_TYPES: Set<ChalkPrimitiveType | undefined | null> =
+  new Set([`<class 'datetime.date'>`, `<class 'datetime.datetime'>`]);
 
 const APPLICATION_JSON = "application/json;charset=utf-8";
 const APPLICATION_OCTET = "application/octet-stream";
@@ -159,20 +157,22 @@ interface ChalkErrorData {
   resolver?: string;
 }
 
+export interface ChalkOnlineQueryRawData {
+  field: string;
+  value: any;
+  pkey?: null | string | number;
+  error?: ChalkErrorData;
+  ts?: string;
+  meta?: {
+    chosen_resolver_fqn?: string;
+    cache_hit?: boolean;
+    primitive_type?: ChalkPrimitiveType;
+    version?: number;
+  };
+}
+
 export interface ChalkOnlineQueryRawResponse {
-  data: {
-    field: string;
-    value: any;
-    pkey?: null | string | number;
-    error?: ChalkErrorData;
-    ts?: string;
-    meta?: {
-      chosen_resolver_fqn?: string;
-      cache_hit?: boolean;
-      primitive_type?: ChalkPrimitiveType;
-      version?: number;
-    };
-  }[];
+  data: ChalkOnlineQueryRawData[];
   errors?: ChalkErrorData[];
   meta?: RawQueryResponseMeta;
 }

--- a/src/_interface.ts
+++ b/src/_interface.ts
@@ -1,9 +1,13 @@
-import { ChalkScalar, TimestampFormat } from "./_types";
-export type { TimestampFormat };
+import { ChalkScalar } from "./_types";
 
 export interface ChalkGetRunStatusResponse {
   id: string;
   status: ChalkResolverRunStatus;
+}
+
+export enum TimestampFormat {
+  EPOCH_MILLIS = "EPOCH_MILLIS",
+  ISO_8601 = "ISO_8601",
 }
 
 export interface ChalkUploadSingleRequest<TFeatureMap> {

--- a/src/_interface.ts
+++ b/src/_interface.ts
@@ -1,4 +1,5 @@
-import { ChalkScalar } from "./_types";
+import { ChalkScalar, TimestampFormat } from "./_types";
+export type { TimestampFormat };
 
 export interface ChalkGetRunStatusResponse {
   id: string;
@@ -83,7 +84,7 @@ export interface ChalkOnlineQueryRequest<
 
   // Set additional options to be considered by the Chalk query planner; typically
   // provided by Chalk support for advanced use cases or beta functionality.
-  plannerOptions?:  {[index: string]: string | boolean | number};
+  plannerOptions?: { [index: string]: string | boolean | number };
 }
 
 export interface ChalkQueryMeta {

--- a/src/_response.ts
+++ b/src/_response.ts
@@ -1,0 +1,41 @@
+import { ChalkOnlineQueryRawResponse } from "./_http";
+import { ChalkOnlineQueryResponse } from "./_interface";
+import { ChalkScalar } from "./_types";
+import { fromEntries } from "./_utils";
+import { mapRawResponseMeta } from "./_meta";
+
+type FeatureEntry<
+  TFeatureMap = Record<string, ChalkScalar>,
+  TOutput extends keyof TFeatureMap = keyof TFeatureMap
+> = ChalkOnlineQueryResponse<TFeatureMap, TOutput>["data"][any];
+
+export const parseOnlineQueryResponse = <
+  TFeatureMap = Record<string, ChalkScalar>,
+  TOutput extends keyof TFeatureMap = keyof TFeatureMap
+>(
+  rawResult: ChalkOnlineQueryRawResponse
+): ChalkOnlineQueryResponse<TFeatureMap, TOutput> => {
+  return {
+    data: fromEntries(
+      rawResult.data.map((d): [string, FeatureEntry] => [
+        d.field,
+        {
+          value: d.value,
+          computedAt: d.ts != null ? new Date(d.ts) : undefined,
+          error: d.error,
+          meta: d.meta && {
+            chosenResolverFqn: d.meta.chosen_resolver_fqn,
+            cacheHit: d.meta.cache_hit,
+            primitiveType: d.meta.primitive_type,
+            version: d.meta.version,
+          },
+        },
+      ])
+    ) as ChalkOnlineQueryResponse<TFeatureMap, TOutput>["data"],
+    errors:
+      rawResult.errors == null || rawResult.errors.length
+        ? undefined
+        : rawResult.errors,
+    meta: rawResult.meta ? mapRawResponseMeta(rawResult.meta) : undefined,
+  };
+};

--- a/src/_response.ts
+++ b/src/_response.ts
@@ -1,6 +1,10 @@
-import { ChalkOnlineQueryRawResponse } from "./_http";
+import {
+  CHALK_DATE_TYPES,
+  ChalkOnlineQueryRawData,
+  ChalkOnlineQueryRawResponse,
+} from "./_http";
 import { ChalkOnlineQueryResponse } from "./_interface";
-import { ChalkScalar } from "./_types";
+import { ChalkClientConfig, ChalkScalar } from "./_types";
 import { fromEntries } from "./_utils";
 import { mapRawResponseMeta } from "./_meta";
 
@@ -9,28 +13,45 @@ type FeatureEntry<
   TOutput extends keyof TFeatureMap = keyof TFeatureMap
 > = ChalkOnlineQueryResponse<TFeatureMap, TOutput>["data"][any];
 
+const processDataValue = (
+  d: ChalkOnlineQueryRawData,
+  { timestampFormat }: Pick<ChalkClientConfig, "timestampFormat">
+): ChalkScalar => {
+  if (
+    timestampFormat === "EPOCH_MILLIS" &&
+    CHALK_DATE_TYPES.has(d.meta?.primitive_type)
+  ) {
+    return new Date(d.value).getTime();
+  }
+
+  return d.value;
+};
+
 export const parseOnlineQueryResponse = <
   TFeatureMap = Record<string, ChalkScalar>,
   TOutput extends keyof TFeatureMap = keyof TFeatureMap
 >(
-  rawResult: ChalkOnlineQueryRawResponse
+  rawResult: ChalkOnlineQueryRawResponse,
+  config: Pick<ChalkClientConfig, "timestampFormat">
 ): ChalkOnlineQueryResponse<TFeatureMap, TOutput> => {
   return {
     data: fromEntries(
-      rawResult.data.map((d): [string, FeatureEntry] => [
-        d.field,
-        {
-          value: d.value,
-          computedAt: d.ts != null ? new Date(d.ts) : undefined,
-          error: d.error,
-          meta: d.meta && {
-            chosenResolverFqn: d.meta.chosen_resolver_fqn,
-            cacheHit: d.meta.cache_hit,
-            primitiveType: d.meta.primitive_type,
-            version: d.meta.version,
+      rawResult.data.map((d): [string, FeatureEntry] => {
+        return [
+          d.field,
+          {
+            value: processDataValue(d, config),
+            computedAt: d.ts != null ? new Date(d.ts) : undefined,
+            error: d.error,
+            meta: d.meta && {
+              chosenResolverFqn: d.meta.chosen_resolver_fqn,
+              cacheHit: d.meta.cache_hit,
+              primitiveType: d.meta.primitive_type,
+              version: d.meta.version,
+            },
           },
-        },
-      ])
+        ];
+      })
     ) as ChalkOnlineQueryResponse<TFeatureMap, TOutput>["data"],
     errors:
       rawResult.errors == null || rawResult.errors.length

--- a/src/_response.ts
+++ b/src/_response.ts
@@ -15,10 +15,10 @@ type FeatureEntry<
 
 const processDataValue = (
   d: ChalkOnlineQueryRawData,
-  { timestampFormat }: Pick<ChalkClientConfig, "timestampFormat">
+  shouldConvertTimestampsToMillis = false
 ): ChalkScalar => {
   if (
-    timestampFormat === "EPOCH_MILLIS" &&
+    shouldConvertTimestampsToMillis &&
     CHALK_DATE_TYPES.has(d.meta?.primitive_type)
   ) {
     return new Date(d.value).getTime();
@@ -34,13 +34,16 @@ export const parseOnlineQueryResponse = <
   rawResult: ChalkOnlineQueryRawResponse,
   config: Pick<ChalkClientConfig, "timestampFormat">
 ): ChalkOnlineQueryResponse<TFeatureMap, TOutput> => {
+  const shouldConvertTimestampsToMillis =
+    config.timestampFormat === "EPOCH_MILLIS";
+
   return {
     data: fromEntries(
       rawResult.data.map((d): [string, FeatureEntry] => {
         return [
           d.field,
           {
-            value: processDataValue(d, config),
+            value: processDataValue(d, shouldConvertTimestampsToMillis),
             computedAt: d.ts != null ? new Date(d.ts) : undefined,
             error: d.error,
             meta: d.meta && {

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,10 +1,15 @@
+export enum TimestampFormat {
+  EPOCH_MILLIS = "EPOCH_MILLIS",
+  ISO_8601 = "ISO_8601",
+}
+
 export interface ChalkClientConfig {
   activeEnvironment: string | undefined;
   apiServer: string;
   clientId: string;
   clientSecret: string;
   queryServer: string;
-  timestampFormat: "EPOCH_MILLIS" | "ISO_8601";
+  timestampFormat: TimestampFormat;
 }
 
 export interface CustomFetchClient<

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,7 +1,5 @@
-export enum TimestampFormat {
-  EPOCH_MILLIS = "EPOCH_MILLIS",
-  ISO_8601 = "ISO_8601",
-}
+import { TimestampFormat } from "./_interface";
+
 
 export interface ChalkClientConfig {
   activeEnvironment: string | undefined;

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -4,7 +4,7 @@ export interface ChalkClientConfig {
   clientId: string;
   clientSecret: string;
   queryServer: string;
-  timestampFormat: "UNIX" | "ISO_8601";
+  timestampFormat: "EPOCH_MILLIS" | "ISO_8601";
 }
 
 export interface CustomFetchClient<

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,9 +1,10 @@
 export interface ChalkClientConfig {
+  activeEnvironment: string | undefined;
+  apiServer: string;
   clientId: string;
   clientSecret: string;
-  apiServer: string;
   queryServer: string;
-  activeEnvironment: string | undefined;
+  timestampFormat: "UNIX" | "ISO_8601";
 }
 
 export interface CustomFetchClient<

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,5 @@ export {
   ChalkTriggerResolverRunRequest,
   ChalkTriggerResolverRunResponse,
   ChalkWhoamiResponse,
+  TimestampFormat,
 } from "./_interface";


### PR DESCRIPTION
allow single, multi, and bulk queries to translate timestamps between numeric values (`EPOCH_MILLIS`) and timestamp strings `ISO_8601`

Surfaces a new option and fixes an issue where datetime-like bulk queries would incorrectly be read as millis when a similar online query would return a timestamp