### PR TITLE
Add branch argument to ChalkClient initialization and request functions

### DIFF
--- a/src/__test__/client.test.ts
+++ b/src/__test__/client.test.ts
@@ -34,16 +34,18 @@ describe("ChalkClient", () => {
     const client = new ChalkClient({
       activeEnvironment: "a",
       apiServer: "b",
-      clientId: "c",
-      clientSecret: "d",
+      branch: "c",
+      clientId: "d",
+      clientSecret: "e",
       timestampFormat: TimestampFormat.EPOCH_MILLIS,
     });
 
     expect(getConfig(client)).toEqual<ChalkClientConfig>({
       activeEnvironment: "a",
       apiServer: "b",
-      clientId: "c",
-      clientSecret: "d",
+      branch: "c",
+      clientId: "d",
+      clientSecret: "e",
       queryServer: "b",
       timestampFormat: TimestampFormat.EPOCH_MILLIS,
     });
@@ -52,6 +54,7 @@ describe("ChalkClient", () => {
   it("reads from environment variables when set", () => {
     process.env._CHALK_ACTIVE_ENVIRONMENT = "env";
     process.env._CHALK_API_SERVER = "http://localhost:8000";
+    process.env._CHALK_BRANCH = "not_a_real_branch";
     process.env._CHALK_CLIENT_ID = "client_id";
     process.env._CHALK_CLIENT_SECRET = "secret";
     process.env._CHALK_QUERY_SERVER = "http://localhost:1337";
@@ -61,6 +64,7 @@ describe("ChalkClient", () => {
     expect(getConfig(client)).toEqual<ChalkClientConfig>({
       activeEnvironment: "env",
       apiServer: "http://localhost:8000",
+      branch: "not_a_real_branch",
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: "http://localhost:1337",
@@ -84,6 +88,7 @@ describe("ChalkClient", () => {
     expect(getConfig(client)).toEqual<ChalkClientConfig>({
       activeEnvironment: undefined,
       apiServer: DEFAULT_API_SERVER,
+      branch: undefined,
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: DEFAULT_API_SERVER,
@@ -99,6 +104,7 @@ describe("ChalkClient", () => {
     expect(getConfig(client)).toEqual<ChalkClientConfig>({
       activeEnvironment: undefined,
       apiServer: DEFAULT_API_SERVER,
+      branch: undefined,
       clientId: "client_id",
       clientSecret: "secret",
       queryServer: "query server",

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -7,6 +7,7 @@ import { ChalkErrorCategory, ChalkErrorCode } from "./_interface";
 
 export interface ChalkHttpHeaders {
   "X-Chalk-Env-Id"?: string;
+  "X-Chalk-Branch-Id"?: string;
   "User-Agent"?: string;
 }
 
@@ -237,6 +238,10 @@ export class ChalkHTTPService {
 
       if (effectiveTimeout != null) {
         headers.set("X-Chalk-Timeout", effectiveTimeout.toString());
+      }
+
+      if (callArgs.headers?.["X-Chalk-Branch-Id"] != null) {
+        headers.set("X-Chalk-Branch-Id", callArgs.headers["X-Chalk-Branch-Id"]);
       }
 
       const body =

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,9 +1,9 @@
 import { TimestampFormat } from "./_interface";
 
-
 export interface ChalkClientConfig {
   activeEnvironment: string | undefined;
   apiServer: string;
+  branch: string | undefined;
   clientId: string;
   clientSecret: string;
   queryServer: string;
@@ -24,6 +24,7 @@ export interface ChalkEnvironmentVariables {
   _CHALK_API_SERVER: string;
   _CHALK_QUERY_SERVER: string;
   _CHALK_ACTIVE_ENVIRONMENT: string;
+  _CHALK_BRANCH: string;
 }
 
 /**


### PR DESCRIPTION
Adds a branch argument to the initialization of the chalk client and during requests to several endpoints.

Unit tests as well 