### PR TITLE
Consolidate and expose ChalkErrorData

### DIFF
--- a/src/_bulk_response.ts
+++ b/src/_bulk_response.ts
@@ -8,7 +8,7 @@ import {
   Utf8,
 } from "apache-arrow";
 import { RawQueryResponseMeta } from "./_http";
-import { ChalkError, ChalkQueryMeta, TimestampFormat } from "./_interface";
+import { ChalkErrorData, ChalkQueryMeta, TimestampFormat } from "./_interface";
 import { mapRawResponseMeta } from "./_meta";
 import { ChalkClientConfig } from "./_types";
 
@@ -81,7 +81,6 @@ export function parseByteModel(raw: Buffer): ByteModel {
   }
 
   const concatenatedByteObjects2 = raw.subarray(offset, bodyLen2 + offset);
-  offset += bodyLen2;
 
   return {
     attrs: JSON.parse(decoder.decode(attrsBytes)),
@@ -104,7 +103,7 @@ export function sortJsonDictByKeys(json: {
 export interface QueryChunkResult {
   data: any[];
   meta?: ChalkQueryMeta;
-  errors?: ChalkError[];
+  errors?: ChalkErrorData[];
 }
 
 interface QueryChunkResultsWithOffset {
@@ -128,7 +127,7 @@ export function processArrowTable(
       DataType.isTimestamp(vector.type)
     ) {
       const newVector = vectorFromArray<Utf8>(
-        Array.from(vector, (data) => (new Date(data)).toISOString()),
+        Array.from(vector, (data) => new Date(data).toISOString()),
         new Utf8()
       );
       newTable = newTable.setChildAt(index, newVector);

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -1,6 +1,6 @@
 import { parseFeatherQueryResponse } from "./_bulk_response";
 import { DEFAULT_API_SERVER } from "./_const";
-import { chalkError } from "./_errors";
+import { ChalkError } from "./_errors";
 import {
   IntermediateRequestBodyJSON,
   serializeMultipleQueryInputFeather,
@@ -333,7 +333,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
 
     if (rawResult.errors != null && rawResult.errors.length > 0) {
       const errorText = rawResult.errors.map((e) => e.message).join("; ");
-      throw chalkError(errorText, {
+      throw new ChalkError(errorText, {
         info: rawResult.errors,
       });
     }

--- a/src/_errors.ts
+++ b/src/_errors.ts
@@ -1,25 +1,17 @@
-
-interface ChalkErrorInfo {
-  code: string;
-  category: string;
-  message: string;
-
-  feature?: string;
-  resolver?: string;
-}
+import { ChalkErrorData } from "./_interface";
 
 interface ChalkErrorExtra {
   httpStatus?: number;
   httpStatusText?: string;
-  info?: ChalkErrorInfo[];
+  info?: ChalkErrorData[];
 }
 
 export class ChalkError extends Error {
   public httpStatus: number | undefined;
   public httpStatusText: string | undefined;
-  public info: ChalkErrorInfo[];
+  public info: ChalkErrorData[];
 
-  constructor(message: string, extra: ChalkErrorExtra) {
+  constructor(message: string, extra: ChalkErrorExtra = {}) {
     super(message);
     this.name = ChalkError.name;
     this.httpStatus = extra.httpStatus;
@@ -28,10 +20,6 @@ export class ChalkError extends Error {
   }
 }
 
-export function isChalkError(error: any): error is ChalkError {
+export function isChalkError(error: unknown): error is ChalkError {
   return error instanceof ChalkError;
-}
-
-export function chalkError(message: string, extra?: ChalkErrorExtra) {
-  return new ChalkError(message, extra ?? {});
 }

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -1,9 +1,9 @@
-import { chalkError, ChalkError, isChalkError } from "./_errors";
+import { ChalkError, isChalkError } from "./_errors";
 import { ChalkClientConfig, CustomFetchClient } from "./_types";
 import { urlJoin } from "./_utils";
 
 import { USER_AGENT } from "./_user_agent";
-import { ChalkErrorCategory, ChalkErrorCode } from "./_interface";
+import { ChalkErrorData } from "./_interface";
 
 export interface ChalkHttpHeaders {
   "X-Chalk-Env-Id"?: string;
@@ -128,9 +128,9 @@ export class CredentialsHolder {
         if (isChalkError(e)) {
           throw e;
         } else if (e instanceof Error) {
-          throw chalkError(e.message);
+          throw new ChalkError(e.message);
         } else {
-          throw chalkError(
+          throw new ChalkError(
             "Unable to authenticate to Chalk servers. Please check your environment config"
           );
         }
@@ -143,19 +143,6 @@ export class CredentialsHolder {
   clear() {
     this.credentials = null;
   }
-}
-
-interface ChalkErrorData {
-  code: ChalkErrorCode;
-  category: ChalkErrorCategory;
-  message: string;
-  exception?: {
-    kind: string;
-    message: string;
-    stacktrace: string;
-  };
-  feature?: string;
-  resolver?: string;
 }
 
 export interface ChalkOnlineQueryRawData {
@@ -279,7 +266,7 @@ export class ChalkHTTPService {
         }
       } catch (e) {
         if (e instanceof DOMException) {
-          throw chalkError(
+          throw new ChalkError(
             "Request timed out after " + effectiveTimeout + "ms"
           );
         } else {

--- a/src/_interface.ts
+++ b/src/_interface.ts
@@ -170,7 +170,7 @@ export type ChalkErrorCategory =
   // connection failed, or an error occurred within Chalk.
   | "NETWORK";
 
-export interface ChalkError {
+export interface ChalkErrorData {
   // The type of the error.
   code: ChalkErrorCode;
 
@@ -230,7 +230,7 @@ export interface ChalkOnlineQueryResponse<
 
       // The error code encountered in resolving this feature.
       // If no error occurred, this field is empty.
-      error?: ChalkError;
+      error?: ChalkErrorData;
 
       // If an error occurred resolving this feature, this field will be 'false'.
       valid?: boolean;
@@ -242,7 +242,7 @@ export interface ChalkOnlineQueryResponse<
 
   // Errors encountered while running the resolvers.
   // If there are no errors, `errors` will be undefined.
-  errors?: ChalkError[];
+  errors?: ChalkErrorData[];
 
   // Only included if `include_meta` is true.
   meta?: ChalkQueryMeta;
@@ -303,7 +303,7 @@ export interface ChalkOnlineBulkQueryResponse<
     [K in TOutput]: TFeatureMap[K];
   }[];
   meta?: ChalkQueryMeta;
-  errors?: ChalkError[];
+  errors?: ChalkErrorData[];
 }
 
 export type ChalkResolverRunStatus = "received" | "succeeded" | "failed";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { ChalkError, isChalkError } from "./_errors";
 export { CredentialsHolder } from "./_http";
 export {
   ChalkClientInterface,
+  ChalkErrorData,
   ChalkGetRunStatusResponse,
   ChalkOnlineQueryRequest,
   ChalkOnlineQueryResponse,


### PR DESCRIPTION
We had three types for Chalk Error metadata: `ChalkError`, `ChalkErrorInfo`, and `ChalkErrorData`. Consolidates the name to `ChalkErrorData` (but uses the source from the best documented one `ChalkError`) and exposes it from the package.

Also light clean up - removes the `chalkError` function in favor of  `new ChalkError`