### PR TITLE
Send Planner Option to Pack Group Structs and Avoid Using Large Lists to Pack Them

### DIFF
--- a/src/_bulk_response.ts
+++ b/src/_bulk_response.ts
@@ -38,7 +38,7 @@ const assertBufferBeginsWithMagicString = (
   );
   if (decoder.decode(responseMagicBytes) !== MULTI_QUERY_RESPONSE_MAGIC_STR) {
     throw new Error(
-      "Bulk query response was not prefixed with appropriate string constant, got "
+      "Bulk query response was not prefixed with appropriate string constant"
     );
   }
 

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -267,6 +267,11 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
           meta: request.queryMeta,
           query_name: request.queryName,
           staleness: singleQuery.staleness,
+          planner_options: {
+            pack_groups_into_structs: true,
+            // arrow JS implementation cannot handle large lists, must send option to allow parsing
+            pack_groups_avoid_large_list: true,
+          },
         };
       }
     );
@@ -306,7 +311,9 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       staleness: request.staleness,
       planner_options: {
         pack_groups_into_structs: true,
+        // arrow JS implementation cannot handle large lists, must send option to allow parsing
         pack_groups_avoid_large_list: true,
+        ...request.plannerOptions,
       },
       now: request.now,
     };

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -304,6 +304,10 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       meta: request.queryMeta,
       query_name: request.queryName,
       staleness: request.staleness,
+      planner_options: {
+        pack_groups_into_structs: true,
+        pack_groups_avoid_large_list: true,
+      },
       now: request.now,
     };
 
@@ -350,9 +354,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     }
   }
 
-  private getHeaders(
-    requestOptions?: ChalkRequestOptions,
-  ): ChalkHttpHeaders {
+  private getHeaders(requestOptions?: ChalkRequestOptions): ChalkHttpHeaders {
     const headers: ChalkHttpHeaders = this.config.activeEnvironment
       ? {
           "X-Chalk-Env-Id": this.config.activeEnvironment,

--- a/src/_feather.ts
+++ b/src/_feather.ts
@@ -15,6 +15,7 @@ export interface IntermediateRequestBodyJSON<
   meta?: {
     [key: string]: string;
   };
+  planner_options?: Record<string, unknown>;
   query_name?: string;
   staleness?: {
     [K in keyof TFeatureMap]?: string;

--- a/src/_interface.ts
+++ b/src/_interface.ts
@@ -293,6 +293,9 @@ export interface ChalkOnlineBulkQueryRequest<
 
   // `now` should be an ISO-formatted "zoned datetime" or "instant" string.
   now?: string;
+  // Set additional options to be considered by the Chalk query planner; typically
+  // provided by Chalk support for advanced use cases or beta functionality.
+  plannerOptions?: { [index: string]: string | boolean | number };
 }
 
 export interface ChalkOnlineBulkQueryResponse<


### PR DESCRIPTION
The Chalk-ts bulk feather response does not parse group_df's, so two changes:
- Add the planner option `pack_groups_into_structs` to bypass the online feather query's default behavior
- Pass a new option to allow for these responses to be packed into regular lists (arrow-js does not understand large lists)

Also a refactor of `parseBytes` to make it slightly more readable