### PR TITLE
Add top-level support for query_context in query request objects

### DIFF
--- a/src/_client.ts
+++ b/src/_client.ts
@@ -224,6 +224,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
         context: {
           tags: request.scopeTags,
         },
+        query_context: request.query_context,
         correlation_id: request.correlationId,
         deployment_id: request.previewDeploymentId,
         meta: request.queryMeta,
@@ -262,6 +263,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
           context: {
             tags: singleQuery.scopeTags,
           },
+          query_context: request.query_context,
           correlation_id: request.correlationId,
           deployment_id: request.previewDeploymentId,
           meta: request.queryMeta,
@@ -304,6 +306,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       context: {
         tags: request.scopeTags,
       },
+      query_context: request.query_context,
       correlation_id: request.correlationId,
       deployment_id: request.previewDeploymentId,
       meta: request.queryMeta,

--- a/src/_feather.ts
+++ b/src/_feather.ts
@@ -10,6 +10,9 @@ export interface IntermediateRequestBodyJSON<
   context?: {
     tags?: string[];
   };
+  query_context?: {
+    [key: string]: string | number | boolean;
+  };
   correlation_id?: string;
   deployment_id?: string;
   meta?: {

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -356,6 +356,9 @@ export class ChalkHTTPService {
         environment?: string;
         tags?: string[];
       };
+      query_context?: {
+        [key: string]: string | number | boolean;
+      };
       deployment_id?: string;
       correlation_id?: string;
       query_name?: string;

--- a/src/_interface.ts
+++ b/src/_interface.ts
@@ -66,6 +66,11 @@ export interface ChalkOnlineQueryRequest<
     [key: string]: string;
   };
 
+  // Optional context parameters that will be passed with the query
+  query_context?: {
+    [key: string]: string | number | boolean;
+  };
+
   encodingOptions?: {
     encodeStructsAsObjects?: boolean;
   };
@@ -259,6 +264,10 @@ export interface ChalkOnlineMultiQueryRequest<
   queryMeta?: {
     [key: string]: string;
   };
+  // Optional context parameters that will be passed with the query
+  query_context?: {
+    [key: string]: string | number | boolean;
+  };
   encodingOptions?: {
     encodeStructsAsObjects?: boolean;
   };
@@ -287,6 +296,12 @@ export interface ChalkOnlineBulkQueryRequest<
   queryMeta?: {
     [key: string]: string;
   };
+
+  // Optional context parameters that will be passed with the query
+  query_context?: {
+    [key: string]: string | number | boolean;
+  };
+
   encodingOptions?: {
     encodeStructsAsObjects?: boolean;
   };


### PR DESCRIPTION
This PR updates the implementation to treat 'query_context' as a top-level property rather than nesting it under 'context'. Changes were made to relevant interfaces and methods to reflect this, ensuring proper request structure for both online and bulk query methods. This aligns with specified API requirements, promoting consistency and clarity in request handling.



Created with [**Solver**](https://solverai.com)