### PR TITLE
Add versioned header, add array for chalk scalar

### DIFF
--- a/src/_client.ts
+++ b/src/_client.ts
@@ -365,11 +365,13 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   }
 
   private getHeaders(requestOptions?: ChalkRequestOptions): ChalkHttpHeaders {
-    const headers: ChalkHttpHeaders = this.config.activeEnvironment
-      ? {
-          "X-Chalk-Env-Id": this.config.activeEnvironment,
-        }
-      : {};
+    const headers: ChalkHttpHeaders = {
+      "X-Chalk-Features-Versioned": true,
+    };
+
+    if (this.config.activeEnvironment) {
+      headers["X-Chalk-Env-Id"] = this.config.activeEnvironment;
+    }
 
     const branch = requestOptions?.branch ?? this.config.branch;
     if (branch != null) {

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -134,7 +134,8 @@ export interface ChalkRequestOptions {
   /**
    * Additional headers to include in this request. These headers will be merged with the headers provided at the client level.
    */
-  additionalHeaders?: Record<string, string>;
+  additionalHeaders?: ChalkHttpHeaders &
+    Record<string, string | number | boolean>;
 }
 
 export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
@@ -365,9 +366,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   }
 
   private getHeaders(requestOptions?: ChalkRequestOptions): ChalkHttpHeaders {
-    const headers: ChalkHttpHeaders = {
-      "X-Chalk-Features-Versioned": true,
-    };
+    const headers: ChalkHttpHeaders = {};
 
     if (this.config.activeEnvironment) {
       headers["X-Chalk-Env-Id"] = this.config.activeEnvironment;

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -8,6 +8,7 @@ import { ChalkErrorData } from "./_interface";
 export interface ChalkHttpHeaders {
   "X-Chalk-Env-Id"?: string;
   "X-Chalk-Branch-Id"?: string;
+  "X-Chalk-Features-Versioned"?: boolean;
   "User-Agent"?: string;
 }
 

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -5,9 +5,19 @@ import { urlJoin } from "./_utils";
 import { USER_AGENT } from "./_user_agent";
 import { ChalkErrorData } from "./_interface";
 
+/**
+ * An interface recording available headers that can be sent to the chalk engine to change its behavior.
+ * */
 export interface ChalkHttpHeaders {
   "X-Chalk-Env-Id"?: string;
   "X-Chalk-Branch-Id"?: string;
+  /**
+   * If true, assumes explicit versioning of the versions and ignores default.
+   * This also means that the output data shape always matches the query requested output.
+   *
+   * ex. class.versioned_feature with a default v2 will return the v1 resolver data under the
+   * field "class.versioned_feature", instead of v2 resolver data on the field "class.versioned_feature@v2"
+   * */
   "X-Chalk-Features-Versioned"?: boolean;
   "User-Agent"?: string;
 }

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -38,4 +38,18 @@ declare global {
   }
 }
 
-export type ChalkScalar = string | number | boolean;
+export type ChalkScalarArray = Array<ChalkScalar>;
+
+export interface ChalkScalarObject {
+  [key: string]: ChalkScalar;
+}
+
+/**
+ * Represents a scalar feature value returned by chalk. ChalkScalars
+ */
+export type ChalkScalar =
+  | string
+  | number
+  | boolean
+  | ChalkScalarArray
+  | ChalkScalarObject;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { ChalkClient, ChalkClientOpts } from "./_client";
 export { ChalkError, isChalkError } from "./_errors";
-export { CredentialsHolder } from "./_http";
+export { CredentialsHolder, ChalkHttpHeaders } from "./_http";
 export {
   ChalkClientInterface,
   ChalkErrorData,
@@ -19,3 +19,4 @@ export {
   ChalkWhoamiResponse,
   TimestampFormat,
 } from "./_interface";
+export { ChalkScalar } from "./_types";


### PR DESCRIPTION
Adds a version header that makes sure that feautures dont return a `@version` suffix if not requesting a version

Also makes `ChalkScalar` very close to `JSONValue` like types