### PR TITLE
Better typing for chalk headers, Add Headers for Deployment Type and Resource Group

### DIFF
--- a/src/_client.ts
+++ b/src/_client.ts
@@ -5,7 +5,12 @@ import {
   IntermediateRequestBodyJSON,
   serializeMultipleQueryInputFeather,
 } from "./_feather";
-import { ChalkHttpHeaders, ChalkHTTPService, CredentialsHolder } from "./_http";
+import {
+  ChalkHttpHeaders,
+  ChalkHttpHeadersStrict,
+  ChalkHTTPService,
+  CredentialsHolder,
+} from "./_http";
 import {
   ChalkClientInterface,
   ChalkGetRunStatusResponse,
@@ -74,7 +79,7 @@ export interface ChalkClientOpts {
   /**
    * Additional headers to include in all requests made by this client instance.
    */
-  additionalHeaders?: Record<string, string>;
+  additionalHeaders?: ChalkHttpHeaders;
 
   /**
    * A custom fetch client that will replace the fetch polyfill used by default.
@@ -134,8 +139,7 @@ export interface ChalkRequestOptions {
   /**
    * Additional headers to include in this request. These headers will be merged with the headers provided at the client level.
    */
-  additionalHeaders?: ChalkHttpHeaders &
-    Record<string, string | number | boolean>;
+  additionalHeaders?: ChalkHttpHeaders;
 }
 
 export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
@@ -366,7 +370,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   }
 
   private getHeaders(requestOptions?: ChalkRequestOptions): ChalkHttpHeaders {
-    const headers: ChalkHttpHeaders = {};
+    const headers: ChalkHttpHeadersStrict = {};
 
     if (this.config.activeEnvironment) {
       headers["X-Chalk-Env-Id"] = this.config.activeEnvironment;
@@ -381,6 +385,6 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       Object.assign(headers, requestOptions.additionalHeaders);
     }
 
-    return headers;
+    return headers as ChalkHttpHeaders;
   }
 }

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -370,7 +370,9 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   }
 
   private getHeaders(requestOptions?: ChalkRequestOptions): ChalkHttpHeaders {
-    const headers: ChalkHttpHeadersStrict = {};
+    const headers: ChalkHttpHeadersStrict = {
+      "X-Chalk-Deployment-Type": "engine",
+    };
 
     if (this.config.activeEnvironment) {
       headers["X-Chalk-Env-Id"] = this.config.activeEnvironment;

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -12,6 +12,11 @@ export interface ChalkHttpHeadersStrict {
   "X-Chalk-Env-Id"?: string;
   "X-Chalk-Branch-Id"?: string;
   /**
+   * If specified, changes which type of engine deployment to target.
+   * The typescript client does not yet communicate with grpc engines, use carefully!
+   */
+  "X-Chalk-Deployment-Type"?: "engine" | "engine-grpc";
+  /**
    * If true, assumes explicit versioning of the versions and ignores default.
    * This also means that the output data shape always matches the query requested output.
    *
@@ -19,11 +24,20 @@ export interface ChalkHttpHeadersStrict {
    * field "class.versioned_feature", instead of v2 resolver data on the field "class.versioned_feature@v2"
    * */
   "X-Chalk-Features-Versioned"?: boolean;
+  /**
+   * Specifies which resource group should be targeted for executing the query.
+   */
+  "X-Chalk-Resource-Group"?: string;
   "User-Agent"?: string;
 }
 
-export type ChalkHttpHeaders = ChalkHttpHeadersStrict &
-  Record<string, string | boolean | number>;
+type ChalkHttpHeadersKeys = keyof ChalkHttpHeadersStrict;
+interface ChalkHttpHeadersFreeform {
+  [key: Exclude<string, ChalkHttpHeadersKeys>]: string | number | boolean;
+}
+
+export type ChalkHttpHeaders = ChalkHttpHeadersFreeform &
+  ChalkHttpHeadersStrict;
 
 const isoFetch: typeof fetch =
   typeof fetch !== "undefined" ? fetch : require("node-fetch");

--- a/src/_http.ts
+++ b/src/_http.ts
@@ -8,7 +8,7 @@ import { ChalkErrorData } from "./_interface";
 /**
  * An interface recording available headers that can be sent to the chalk engine to change its behavior.
  * */
-export interface ChalkHttpHeaders {
+export interface ChalkHttpHeadersStrict {
   "X-Chalk-Env-Id"?: string;
   "X-Chalk-Branch-Id"?: string;
   /**
@@ -21,6 +21,9 @@ export interface ChalkHttpHeaders {
   "X-Chalk-Features-Versioned"?: boolean;
   "User-Agent"?: string;
 }
+
+export type ChalkHttpHeaders = ChalkHttpHeadersStrict &
+  Record<string, string | boolean | number>;
 
 const isoFetch: typeof fetch =
   typeof fetch !== "undefined" ? fetch : require("node-fetch");
@@ -181,13 +184,13 @@ export class ChalkHTTPService {
   private fetchClient: CustomFetchClient;
   private fetchHeaders: typeof Headers;
   private defaultTimeout: number | undefined;
-  private additionalHeaders: Record<string, string> | undefined;
+  private additionalHeaders: ChalkHttpHeaders | undefined;
 
   constructor(
     fetchClient?: CustomFetchClient,
     fetchHeaders?: typeof Headers,
     defaultTimeout?: number,
-    additionalHeaders?: Record<string, string>
+    additionalHeaders?: ChalkHttpHeaders
   ) {
     this.fetchClient = fetchClient ?? (isoFetch as any); // cast for any's editor
     this.fetchHeaders = fetchHeaders ?? isoHeaders;
@@ -245,12 +248,12 @@ export class ChalkHTTPService {
       // So call site > client
       if (this.additionalHeaders != null) {
         for (const [key, value] of Object.entries(this.additionalHeaders)) {
-          headers.set(key, value);
+          headers.set(key, `${value}`);
         }
       }
       if (callArgs.headers != null) {
         for (const [key, value] of Object.entries(callArgs.headers)) {
-          headers.set(key, value);
+          headers.set(key, `${value}`);
         }
       }
 


### PR DESCRIPTION
Renames `ChalkHttpHeaders` to `ChalkHttpHeadersStrict`, and exports a looser version of `ChalkHttpHeaders` that extends a generic record. This allows the client to specify non-string values in the header (which will still be stringified, but might be nicer to read than `"true"`