### PR TITLE
Add support for new header `client_supported_64bit_types`, add back `client_supports_64bit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepack": "rm -rf build/ && yarn build && rm -rf build/__test__",
     "test": "jest src/__test__",
     "test:watch": "jest --watch",
-    "test:integration": "CHALK_INTEGRATION=1 jest -t='integration tests'",
+    "test:integration": "CHALK_INTEGRATION=1 jest -t='integration tests' --maxWorkers=1",
     "test:integration:watch": "CHALK_INTEGRATION=1 jest --watch -t='integration tests'"
   },
   "dependencies": {

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -89,7 +89,6 @@ maybe("integration tests", () => {
             },
             outputs: ["user.full_name"],
           });
-          console.log(results);
         } catch (e) {
           error = e;
         }

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -286,6 +286,7 @@ maybe("integration tests", () => {
         });
 
         expect(Object.keys(result.data).length).toBe(2);
+        console.log(result);
         expect(result.data[0]["user.id"]).toEqual(BigInt(1));
         expect(result.data[0]["user.full_name"]).toEqual("Donna Davis");
         expect(result.data[1]["user.id"]).toEqual(BigInt(2));

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -108,13 +108,12 @@ maybe("integration tests", () => {
             clientId: "bogus",
             clientSecret: "bogus",
           });
-          const results = await badClient.queryBulk({
+          await badClient.queryBulk({
             inputs: {
               "user.id": [1, 2],
             },
             outputs: ["user.full_name"],
           });
-          console.log(results);
         } catch (e) {
           error = e;
         }
@@ -131,13 +130,12 @@ maybe("integration tests", () => {
         let error = null;
         try {
           const badClient = new ChalkClient<FraudTemplateFeatures>();
-          const results = await badClient.queryBulk({
+          await badClient.queryBulk({
             inputs: {
               "user.id": [1, 2],
             },
             outputs: ["user.full_name"],
           });
-          console.log(results);
         } catch (e) {
           error = e;
         }
@@ -285,7 +283,6 @@ maybe("integration tests", () => {
         });
 
         expect(Object.keys(result.data).length).toBe(2);
-        console.log(result);
         expect(result.data[0]["user.id"]).toEqual(BigInt(1));
         expect(result.data[0]["user.full_name"]).toEqual("Donna Davis");
         expect(result.data[1]["user.id"]).toEqual(BigInt(2));

--- a/src/__test__/json/request_multi.json
+++ b/src/__test__/json/request_multi.json
@@ -9,7 +9,7 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": true,
+      "client_supports_64bit": false
     },
     "body": {
       "schema": {
@@ -103,7 +103,7 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": true,
+      "client_supports_64bit": false
     },
     "body": {
       "schema": {

--- a/src/__test__/json/request_multi.json
+++ b/src/__test__/json/request_multi.json
@@ -9,7 +9,8 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": true
+      "client_supports_64bit": false,
+      "client_supported_64bit_types": ["Int64", "LargeBinary"]
     },
     "body": {
       "schema": {
@@ -103,7 +104,8 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": true
+      "client_supports_64bit": false,
+      "client_supported_64bit_types": ["Int64", "LargeBinary"]
     },
     "body": {
       "schema": {

--- a/src/__test__/json/request_multi.json
+++ b/src/__test__/json/request_multi.json
@@ -9,8 +9,7 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": false,
-      "client_supported_64bit_types": ["Int64", "LargeBinary"]
+      "client_supports_64bit": true,
     },
     "body": {
       "schema": {
@@ -104,8 +103,7 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": false,
-      "client_supported_64bit_types": ["Int64", "LargeBinary"]
+      "client_supports_64bit": true,
     },
     "body": {
       "schema": {

--- a/src/__test__/json/request_single.json
+++ b/src/__test__/json/request_single.json
@@ -9,7 +9,8 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": true
+      "client_supports_64bit": false,
+      "client_supported_64bit_types": ["Int64", "LargeBinary"]
     },
     "body": {
       "schema": {

--- a/src/__test__/json/request_single.json
+++ b/src/__test__/json/request_single.json
@@ -9,8 +9,7 @@
       },
       "feather_body_type": "RECORD_BATCHES",
       "response_compression_scheme": "uncompressed",
-      "client_supports_64bit": false,
-      "client_supported_64bit_types": ["Int64", "LargeBinary"]
+      "client_supports_64bit": false
     },
     "body": {
       "schema": {

--- a/src/__test__/serialization.test.ts
+++ b/src/__test__/serialization.test.ts
@@ -34,7 +34,8 @@ describe("featherRequestHeaderFromBody", () => {
       },
       feather_body_type: "RECORD_BATCHES",
       response_compression_scheme: "uncompressed",
-      client_supports_64bit: true,
+      client_supports_64bit: false,
+      client_supported_64bit_types: ["Int64", "LargeBinary"],
     });
   });
 

--- a/src/_feather.ts
+++ b/src/_feather.ts
@@ -38,7 +38,8 @@ interface OnlineQueryFeatherRequestHeader<
   // these are the only currently supported values
   feather_body_type: "RECORD_BATCHES";
   response_compression_scheme: "uncompressed";
-  client_supports_64bit: true;
+  client_supports_64bit: false;
+  client_supported_64bit_types: string[];
 }
 
 export function featherRequestHeaderFromBody<
@@ -52,7 +53,8 @@ export function featherRequestHeaderFromBody<
     ...rest,
     feather_body_type: "RECORD_BATCHES",
     response_compression_scheme: "uncompressed",
-    client_supports_64bit: true,
+    client_supports_64bit: false,
+    client_supported_64bit_types: ["Int64", "LargeBinary"],
   };
 }
 


### PR DESCRIPTION
Adds back a query header `client_supports_64bit` that has us downcasting the client 
Adds a new option `client_supported_64bit_types` that helps us know that the arrow-js implementation **does** know about int64 and LargeBinary, but not other types