### PR TITLE
option to use credential exchange query server

### DIFF
--- a/src/__test__/client.test.ts
+++ b/src/__test__/client.test.ts
@@ -51,6 +51,7 @@ describe("ChalkClient", () => {
       clientSecret: "e",
       queryServer: undefined,
       timestampFormat: TimestampFormat.EPOCH_MILLIS,
+      useQueryServerFromCredentialExchange: false,
     });
   });
 
@@ -72,6 +73,7 @@ describe("ChalkClient", () => {
       clientSecret: "secret",
       queryServer: "http://localhost:1337",
       timestampFormat: TimestampFormat.ISO_8601,
+      useQueryServerFromCredentialExchange: false,
     });
   });
 
@@ -96,6 +98,7 @@ describe("ChalkClient", () => {
       clientSecret: "secret",
       queryServer: undefined,
       timestampFormat: TimestampFormat.ISO_8601,
+      useQueryServerFromCredentialExchange: false,
     });
   });
 
@@ -112,6 +115,7 @@ describe("ChalkClient", () => {
       clientSecret: "secret",
       queryServer: "query server",
       timestampFormat: TimestampFormat.ISO_8601,
+      useQueryServerFromCredentialExchange: false,
     });
   });
 

--- a/src/__test__/client.test.ts
+++ b/src/__test__/client.test.ts
@@ -49,7 +49,7 @@ describe("ChalkClient", () => {
       branch: "c",
       clientId: "d",
       clientSecret: "e",
-      queryServer: "b",
+      queryServer: undefined,
       timestampFormat: TimestampFormat.EPOCH_MILLIS,
     });
   });
@@ -94,7 +94,7 @@ describe("ChalkClient", () => {
       branch: undefined,
       clientId: "client_id",
       clientSecret: "secret",
-      queryServer: DEFAULT_API_SERVER,
+      queryServer: undefined,
       timestampFormat: TimestampFormat.ISO_8601,
     });
   });

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -232,6 +232,31 @@ maybe("integration tests", () => {
     );
 
     it(
+      "query simple user directly to query server",
+      async () => {
+        const directQueryClient = (client =
+          new ChalkClient<FraudTemplateFeatures>({
+            clientId: process.env.CI_CHALK_CLIENT_ID,
+            clientSecret: process.env.CI_CHALK_CLIENT_SECRET,
+            apiServer: "https://api.chalk.ai",
+            useQueryServerFromCredentialExchange: true,
+          }));
+
+        const result = await directQueryClient.query({
+          inputs: {
+            "user.id": 2,
+          },
+          outputs: ["user.id", "user.gender"],
+        });
+
+        expect(Object.keys(result.data).length).toBe(2);
+        expect(result.data["user.id"].value).toBe(2);
+        expect(result.data["user.gender"].value).toBe("f");
+      },
+      INTEGRATION_TEST_TIMEOUT
+    );
+
+    it(
       "query alternate struct encodings",
       async () => {
         const result = await client.query({

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -16,7 +16,7 @@ interface FraudTemplateFeatures {
 }
 
 const maybe = Boolean(process.env.CHALK_INTEGRATION) ? describe : describe.skip;
-const INTEGRATION_TEST_TIMEOUT = 10_000; // 10s
+const INTEGRATION_TEST_TIMEOUT = 30_000; // 30s
 
 maybe("integration tests", () => {
   let client: ChalkClient;
@@ -31,7 +31,7 @@ maybe("integration tests", () => {
   beforeEach(() => {
     // Cold-starts for a preview deployment can be slow, so we allow a very generous timeout
     // for all of our outbound network calls
-    jest.setTimeout(30_000);
+    jest.setTimeout(INTEGRATION_TEST_TIMEOUT);
   });
 
   describe("test queryServer", () => {

--- a/src/__test__/queryServer.test.ts
+++ b/src/__test__/queryServer.test.ts
@@ -1,0 +1,87 @@
+import { ChalkClient } from "../_client";
+
+describe("ChalkClient getQueryServer", () => {
+  const injectedFetch = (req: any, init: RequestInit | undefined): any => {
+    if (req.endsWith("/v1/oauth/token")) {
+      return Promise.resolve({
+        status: 200,
+        json: () => ({
+          access_token: "test-access-token",
+          token_type: "test-access-token-type",
+          primary_environment: "server-creds-environment",
+          expires_in: 99999,
+          engines: { not_a_real_environment: "query_server_from_credentials" },
+        }),
+      });
+    }
+    return Promise.resolve({
+      status: 200,
+      json: () => ({
+        data: [
+          {
+            field: "user.id",
+            value: "injected!",
+            ts: "2023-01-01",
+          },
+        ],
+      }),
+    });
+  };
+
+  it("Should use the query server passed in as an argument if available", async () => {
+    const client = new ChalkClient({
+      clientId: "not_a_real_client",
+      clientSecret: "not_a_real_client_secret",
+      apiServer: "not_a_real_api_server",
+      queryServer: "not_a_real_query_server",
+      fetch: injectedFetch,
+    });
+
+    const queryServer = await client.getQueryServer();
+
+    expect(queryServer).toBe("not_a_real_query_server");
+  });
+
+  it("Should fall back to the api server passed in as an argument if available", async () => {
+    const client = new ChalkClient({
+      clientId: "not_a_real_client",
+      clientSecret: "not_a_real_client_secret",
+      apiServer: "not_a_real_api_server",
+      fetch: injectedFetch,
+    });
+
+    const queryServer = await client.getQueryServer();
+
+    expect(queryServer).toBe("not_a_real_api_server");
+  });
+
+  it("Should use the engine credentials if the option is passed ", async () => {
+    const client = new ChalkClient({
+      clientId: "not_a_real_client",
+      clientSecret: "not_a_real_client_secret",
+      apiServer: "not_a_real_api_server",
+      useQueryServerFromCredentialExchange: true,
+      activeEnvironment: "not_a_real_environment",
+      fetch: injectedFetch,
+    });
+
+    const queryServer = await client.getQueryServer();
+
+    expect(queryServer).toBe("query_server_from_credentials");
+  });
+
+  it("Should ignore the engine credentials if the engine is not present", async () => {
+    const client = new ChalkClient({
+      clientId: "not_a_real_client",
+      clientSecret: "not_a_real_client_secret",
+      apiServer: "not_a_real_api_server",
+      useQueryServerFromCredentialExchange: true,
+      activeEnvironment: "not_a_real_environment_2",
+      fetch: injectedFetch,
+    });
+
+    const queryServer = await client.getQueryServer();
+
+    expect(queryServer).toBe("not_a_real_api_server");
+  });
+});

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -180,6 +180,8 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       ),
       queryServer,
       timestampFormat: opts?.timestampFormat ?? TimestampFormat.ISO_8601,
+      useQueryServerFromCredentialExchange:
+        opts?.useQueryServerFromCredentialExchange ?? false,
     };
 
     this.http = new ChalkHTTPService(
@@ -195,6 +197,10 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   async getQueryServer(): Promise<string> {
     if (this.config.queryServer) {
       return this.config.queryServer;
+    }
+
+    if (!this.config.useQueryServerFromCredentialExchange) {
+      return this.config.queryServer || this.config.apiServer;
     }
 
     const { engines, primary_environment } = await this.credentials.get();

--- a/src/_client.ts
+++ b/src/_client.ts
@@ -81,6 +81,8 @@ export interface ChalkClientOpts {
    */
   additionalHeaders?: ChalkHttpHeaders;
 
+  defaultTimeout?: number;
+
   /**
    * A custom fetch client that will replace the fetch polyfill used by default.
    *
@@ -103,7 +105,12 @@ export interface ChalkClientOpts {
    */
   timestampFormat?: ChalkClientConfig["timestampFormat"];
 
-  defaultTimeout?: number;
+  /**
+   * If true, uses
+   *
+   * Defaults to false, the legacy behavior of this client. This will change at the next major release.
+   */
+  useQueryServerFromCredentialExchange?: boolean;
 }
 
 function valueWithEnvFallback(
@@ -151,8 +158,8 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
   constructor(opts?: ChalkClientOpts) {
     const resolvedApiServer: string =
       opts?.apiServer ?? process.env._CHALK_API_SERVER ?? DEFAULT_API_SERVER;
-    const queryServer: string =
-      opts?.queryServer ?? process.env._CHALK_QUERY_SERVER ?? resolvedApiServer;
+    const queryServer: string | undefined =
+      opts?.queryServer ?? process.env._CHALK_QUERY_SERVER;
 
     this.config = {
       activeEnvironment:
@@ -183,6 +190,17 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     );
 
     this.credentials = new CredentialsHolder(this.config, this.http);
+  }
+
+  async getQueryServer(): Promise<string> {
+    if (this.config.queryServer) {
+      return this.config.queryServer;
+    }
+
+    const { engines, primary_environment } = await this.credentials.get();
+    const envId = this.config.activeEnvironment || primary_environment;
+    const engineForEnvironment = envId ? engines?.[envId] : null;
+    return engineForEnvironment || this.config.apiServer;
   }
 
   async whoami(): Promise<ChalkWhoamiResponse> {
@@ -222,7 +240,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     requestOptions?: ChalkRequestOptions
   ): Promise<ChalkOnlineQueryResponse<TFeatureMap, TOutput>> {
     const rawResult = await this.http.v1_query_online({
-      baseUrl: this.config.queryServer,
+      baseUrl: await this.getQueryServer(),
       body: {
         inputs: request.inputs,
         outputs: request.outputs as string[],
@@ -287,7 +305,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     const requestBuffer = serializeMultipleQueryInputFeather(requests);
 
     const rawResult = await this.http.v1_query_feather({
-      baseUrl: this.config.queryServer,
+      baseUrl: await this.getQueryServer(),
       body: requestBuffer.buffer,
       headers: this.getHeaders(requestOptions),
       credentials: this.credentials,
@@ -330,7 +348,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     const requestBuffer = serializeMultipleQueryInputFeather([requestBody]);
 
     const rawResult = await this.http.v1_query_feather({
-      baseUrl: this.config.queryServer,
+      baseUrl: await this.getQueryServer(),
       body: requestBuffer.buffer,
       headers: this.getHeaders(requestOptions),
       credentials: this.credentials,
@@ -348,7 +366,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
     request: ChalkUploadSingleRequest<TFeatureMap>
   ): Promise<void> {
     const rawResult = await this.http.v1_upload_single({
-      baseUrl: this.config.queryServer,
+      baseUrl: await this.getQueryServer(),
       body: {
         inputs: request.features,
         outputs: Object.keys(request.features),

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -6,7 +6,7 @@ export interface ChalkClientConfig {
   branch: string | undefined;
   clientId: string;
   clientSecret: string;
-  queryServer: string;
+  queryServer: string | undefined;
   timestampFormat: TimestampFormat;
 }
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -8,6 +8,7 @@ export interface ChalkClientConfig {
   clientSecret: string;
   queryServer: string | undefined;
   timestampFormat: TimestampFormat;
+  useQueryServerFromCredentialExchange: boolean;
 }
 
 export interface CustomFetchClient<


### PR DESCRIPTION
introduces the option `useQueryServerFromCredentialExchange` that, if set, uses the active environment ID and credentials to find the right query server to send requests to (and falling back to original behavior if option is false or credentials do not have the engine)