### PR TITLE
Migration Guide and Updated README for gRPC Client, Timestamp Option Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ $ chalk codegen typescript --out=generated_types.ts
 ### Modern JavaScript ES6
 
 ```ts
-import { ChalkClient } from "@chalk-ai/client";
+import { ChalkGRPCCLient } from "@chalk-ai/client"
+// import { ChalkClient } from "@chalk-ai/client";
 
 // Import your generated types (recommended)
 import { FeaturesType } from "local/generated_types";
@@ -36,7 +37,7 @@ interface FeaturesType {
   "user.socure_score": number;
 }
 
-const client = new ChalkClient<FeaturesType>();
+const client = new ChalkGRPCCLient<FeaturesType>();
 
 const result = await client.query({
   inputs: {
@@ -55,14 +56,15 @@ console.log(result.data["user.socure_score"].value);
 ### CommonJS
 
 ```ts
-var ChalkClient = require("@chalk-ai/client").ChalkClient;
+var ChalkGRPCClient = require("@chalk-ai/client").ChalkGRPCClient;
+// var ChalkClient = require("@chalk-ai/client").ChalkClient; 
 
 interface FeaturesType {
   "user.id": string;
   "user.socure_score": number;
 }
 
-var client = new ChalkClient<FeaturesType>();
+var client = new ChalkGRPCCLient<FeaturesType>();
 
 client
   .query({
@@ -76,7 +78,133 @@ client
   });
 ```
 
-## Constructor options
+## Constructor options (gRPC)
+
+See [the HTTP Options](#constructor-options-legacy) if you are using the HTTP Client, but we encourage
+reading the [migration guide](#migrating-to-the-grpc-client).
+
+```ts
+new ChalkClient({
+  /**
+   * Your Chalk Client ID. This value will be read from the _CHALK_CLIENT_ID environment variable if not set explicitly.
+   *
+   * If not specified and unset by your environment, an error will be thrown on client creation
+   */
+  clientId?: string;
+
+  /**
+   * Your Chalk Client Secret. This value will be read from the _CHALK_CLIENT_SECRET environment variable if not set explicitly.
+   *
+   * If not specified and unset by your environment, an error will be thrown on client creation
+   */
+  clientSecret?: string;
+
+  /**
+   * The URL of your chalk API server. Defaults to https://api.chalk.ai
+   */
+  apiServer?: string;
+
+  /**
+   * The environment that your client will run against. This value will be read from the _CHALK_ACTIVE_ENVIRONMENT environment variable if not set explicitly.
+   *
+   * If not specified and unset by your environment, an error will be thrown on client creation
+   */
+  activeEnvironment?: string;
+
+  /**
+   * A custom fetch client that will replace the fetch polyfill used by default. Used by both the HTTP and gRPC
+   * clients - the HTTP client for all calls, and the gRPC client for fetching credentials from the API server.
+   *
+   * If not provided, the client will use the default fetch polyfill (native fetch with node-fetch as a fallback).
+   */
+  fetch?: CustomFetchClient;
+
+  /**
+   * A custom fetch headers object that will replace the fetch Headers polyfill used by default. This is primarily for use
+   * with a custom fetch client, and is not the preferred way to add additional headers to requests.
+   *
+   * If not provided, the client will use the default fetch Headers polyfill (native fetch with node-fetch as a fallback).
+   */
+  fetchHeaders?: typeof Headers;
+
+  /**
+   * The format to use for date-type data.
+   *
+   * Defaults to "ISO_8601" (in UTC), also supports "EPOCH_MILLIS" as number of milliseconds since epoch
+   */
+  timestampFormat?: TimestampFormat.ISO_8601 | TimestampFormat.EPOCH_MILLIS;
+
+  /**
+   * By default, the client will try to directly connect to the query client using the metadata provided during
+   * credentials exchange, which returns a mapping between environment and query server. If this option is
+   * truthy, the client will skip this step.
+   *
+   * The queryServer option will take precedence over this option (i.e. this option is essentially useless).
+   * *
+   * Defaults to false.
+   */
+  skipQueryServerFromCredentialExchange?: boolean;
+  
+  /**
+   * Passed to the internal grpc client upon initialization. Under the hood, Chalk uses the @grpc/grpc-js library
+   * and this allows users finer control of their gRPC usage.
+   *
+   * See https://grpc.github.io/grpc/node/grpc.Client.html for more information on what is supported here.
+   */
+  grpcClientOptions?: Partial<ClientOptions>;
+})
+```
+
+## Migrating to the gRPC Client
+
+While Chalk supports both an HTTP Client and a gRPC Client for interfacing with Chalk, we heavily encourage users to use 
+the gRPC Client for better performance, as this targets a more performant gRPC Query Server. After setting up a gRPC 
+Query Server in your Chalk Environment, changing to the gRPC Client can be done in a few steps:
+
+- Use the import `ChalkGRPCClient` instead of `ChalkClient`
+- Check to see if any of the following initialization options need to be changed:
+  - The option `useQueryServerFromCredentialExchange` has been changed to `skipQueryServerFromCredentialExchange` 
+    to better reflect the default behavior.
+  - It is most likely not necessary to change a provided `QueryServer` as most routing is done via SDK-set headers, but 
+    depending on your setup this may need to be directly specified if using a non-standard port - the gRPC query server listens
+    on port `443` by default.
+  - It is **not** necessary to remove the `fetch` or `fetchHeaders` as these are still used during some HTTP routines
+    such as fetching credentials.
+
+After these initialization changes are made, no changes to actual calls should be necessary - the gRPC Client uses the
+same function signatures.
+
+At this moment, only `query()`, `queryBulk()`, and `multiQuery()` are supported - if your usage requires one of the other 
+functions (`whoami()`, `triggerResolverRun()`, `uploadSingle()`, `getRunStatus()`), the legacy `ChalkClient` should be used
+(but ideally only for these four calls - we still strongly recommend partially migrating the query calls to the gRPC Client).
+
+
+
+### Supported environment variables
+
+| Variable                                | Kind         | Description                                                                                                                                      |
+| --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `process.env._CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `clientId` value when constructing your ChalkClient         |
+| `process.env._CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `clientSecret` value when constructing your ChalkClient |
+| `process.env._CHALK_ACTIVE_ENVIRONMENT` | Optional     | The environment that your client should connect to. If not specified, the client will query your project's default environment                   |
+| `process.env._CHALK_API_SERVER`         | Optional     | The API server that the client will communicate with. This defaults to https://api.chalk.ai which should be sufficient for most consumers        |
+
+You can find relevant variables to use with your Chalk Client by
+running `chalk config` with the Chalk command line tool.
+
+```sh
+$ chalk config
+
+Path:          ~~~
+Name:          Organization Token
+Client Id:     <client-id>
+Client Secret: <client-secret>
+Environment:   <active-environment>
+API Server:    https://api.chalk.ai
+Valid Until:   2023-11-10T06:11:17.516000
+```
+
+## Constructor options (Legacy)
 
 ```ts
 new ChalkClient({
@@ -126,29 +254,17 @@ new ChalkClient({
    * Defaults to "ISO_8601" (in UTC), also supports "EPOCH_MILLIS" as number of milliseconds since epoch
    */
   timestampFormat?: TimestampFormat.ISO_8601 | TimestampFormat.EPOCH_MILLIS;
+
+  /**
+   * If true, will try to directly connect to the query client using the metadata provided during
+   * credentials exchange, which returns a mapping between environment and query server.
+   *
+   * The queryServer option will take precedence over this option (i.e. this option is essentially useless).
+   *
+   * Defaults to false, the legacy behavior of this client. This will change at the next major release.
+   */
+  useQueryServerFromCredentialExchange?: boolean;
 })
 ```
 
-### Supported environment variables
 
-| Variable                                | Kind         | Description                                                                                                                                      |
-| --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `process.env._CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `clientId` value when constructing your ChalkClient         |
-| `process.env._CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `clientSecret` value when constructing your ChalkClient |
-| `process.env._CHALK_ACTIVE_ENVIRONMENT` | Optional     | The environment that your client should connect to. If not specified, the client will query your project's default environment                   |
-| `process.env._CHALK_API_SERVER`         | Optional     | The API server that the client will communicate with. This defaults to https://api.chalk.ai which should be sufficient for most consumers        |
-
-You can find relevant variables to use with your Chalk Client by
-running `chalk config` with the Chalk command line tool.
-
-```sh
-$ chalk config
-
-Path:          ~~~
-Name:          Organization Token
-Client Id:     <client-id>
-Client Secret: <client-secret>
-Environment:   <active-environment>
-API Server:    https://api.chalk.ai
-Valid Until:   2023-11-10T06:11:17.516000
-```

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -270,7 +270,7 @@ maybe("integration tests", () => {
             pack_groups_into_structs: true,
           },
           encodingOptions: {
-            encodeStructsAsObjects: false,
+            encodeStructsAsObjects: true,
           },
         });
 

--- a/src/_client_grpc.ts
+++ b/src/_client_grpc.ts
@@ -95,7 +95,7 @@ export class ChalkGRPCClient<TFeatureMap = Record<string, ChalkScalar>>
       requestOptions
     );
 
-    return mapBulkQueryResponseGrpcToChalkOnlineResponse(response);
+    return mapBulkQueryResponseGrpcToChalkOnlineResponse(response, this.config);
   }
 
   async multiQuery<TOutput extends keyof TFeatureMap>(
@@ -116,7 +116,10 @@ export class ChalkGRPCClient<TFeatureMap = Record<string, ChalkScalar>>
       responses: response.responses
         .map((singleResponse, idx) => {
           return singleResponse.bulkResponse
-            ? mapBulkQueryResponseGrpcToChalk(singleResponse.bulkResponse)
+            ? mapBulkQueryResponseGrpcToChalk(
+                singleResponse.bulkResponse,
+                this.config
+              )
             : null;
         })
         .filter(
@@ -141,7 +144,7 @@ export class ChalkGRPCClient<TFeatureMap = Record<string, ChalkScalar>>
       requestOptions
     );
 
-    return mapBulkQueryResponseGrpcToChalk(response);
+    return mapBulkQueryResponseGrpcToChalk(response, this.config);
   }
 
   private async getHeaders(

--- a/src/_interface/_options.ts
+++ b/src/_interface/_options.ts
@@ -53,7 +53,8 @@ export interface BaseChalkClientOpts {
   defaultTimeout?: number;
 
   /**
-   * A custom fetch client that will replace the fetch polyfill used by default.
+   * A custom fetch client that will replace the fetch polyfill used by default. Used by both the HTTP and gRPC
+   * clients - the HTTP client for all calls, and the gRPC client for fetching credentials from the API server.
    *
    * If not provided, the client will use the default fetch polyfill (native fetch with node-fetch as a fallback).
    */
@@ -100,10 +101,10 @@ export interface ChalkGRPCClientOpts extends BaseChalkClientOpts {
   skipQueryServerFromCredentialExchange?: boolean;
 
   /**
-   * Passed to the grpc client upon initialization. Under the hood, Chalk uses the @grpc/grpc-js library
+   * Passed to the internal grpc client upon initialization. Under the hood, Chalk uses the @grpc/grpc-js library
    * and this allows users finer control of their gRPC usage.
    *
-   * Note that
+   * See https://grpc.github.io/grpc/node/grpc.Client.html for more information on what is supported here.
    */
   grpcClientOptions?: Partial<ClientOptions>;
 }

--- a/src/_services/_grpc.ts
+++ b/src/_services/_grpc.ts
@@ -10,7 +10,7 @@ import { ChalkError } from "../_errors";
 import { CredentialsHolder } from "./_credentials";
 import { QueryServiceClient } from "../gen/proto/chalk/engine/v1/query_server.pb";
 import {
-  formUrlforGRPC,
+  formUrlForGRPC,
   headersToMetadata,
   shouldUseInsecureChannel,
 } from "../_utils/_grpc";
@@ -23,18 +23,22 @@ import {
 import { USER_AGENT } from "../_user_agent";
 import { ChalkRequestOptions } from "../_interface/_request";
 
+// Type for what the underlying grpc generated call expects
 export type GRPCCall<Req, Resp> = (
   req: Req,
   metadata: Metadata,
+  // Callback hell to be fixed by this service
   callback: (error: ServiceError | null, resp: Resp) => void
 ) => ClientUnaryCall;
 
+// Function argument signature for what people calling this service should adhere to
 export type GRPCCallArgs<Req> = [
   req: Req,
   metadata: Metadata,
   options: ChalkRequestOptions | null | undefined
 ];
 
+// The API that this service provides
 export type PromisifiedGRPCCall<Req, Resp> = (
   ...args: GRPCCallArgs<Req>
 ) => Promise<Resp>;
@@ -64,7 +68,7 @@ export class ChalkGRPCService {
     this.additionalHeaders = additionalHeaders;
     this.credentialsHolder = credentialsHolder;
     this.queryClient = this.queryClient = new QueryServiceClient(
-      formUrlforGRPC(endpoint),
+      formUrlForGRPC(endpoint),
       shouldUseInsecureChannel(endpoint)
         ? ChannelCredentials.createInsecure()
         : ChannelCredentials.createSsl(),

--- a/src/_utils/_grpc.ts
+++ b/src/_utils/_grpc.ts
@@ -108,10 +108,10 @@ export const mapOnlineMultiQueryRequestChalkToGRPC = <
   };
 };
 
-export const formUrlforGRPC = (url: string): string => {
+export const formUrlForGRPC = (url: string): string => {
   try {
     const urlObj = new URL(url);
-    return `${urlObj.host}:${urlObj.port || 443}`;
+    return `${urlObj.hostname}:${urlObj.port || 443}`;
   } catch {
     return url;
   }

--- a/src/_utils/_grpc.ts
+++ b/src/_utils/_grpc.ts
@@ -5,6 +5,7 @@ import {
   ErrorCodeCategory,
 } from "../gen/proto/chalk/common/v1/chalk_error.pb";
 import {
+  ChalkClientConfig,
   ChalkErrorCategory,
   ChalkErrorCode,
   ChalkErrorData,
@@ -28,6 +29,7 @@ import {
 } from "../gen/proto/chalk/common/v1/online_query.pb";
 import { tableFromIPC } from "apache-arrow";
 import { Metadata } from "@grpc/grpc-js";
+import { processArrowTable } from "../_bulk_response";
 
 /**  Request-Related **/
 
@@ -253,9 +255,14 @@ export const mapBulkQueryResponseGrpcToChalkOnlineResponse = <
   TFeatureMap,
   TOutput extends keyof TFeatureMap
 >(
-  response: OnlineQueryBulkResponse
+  response: OnlineQueryBulkResponse,
+  parseOptions: Pick<ChalkClientConfig, "timestampFormat">
 ): ChalkOnlineQueryResponse<TFeatureMap, TOutput> => {
-  const rawData = tableFromIPC(response.scalarsData).toArray()[0] ?? {};
+  const table = processArrowTable(
+    tableFromIPC(response.scalarsData),
+    parseOptions
+  );
+  const rawData = table.toArray()[0] ?? {};
   const features = Object.keys(rawData).filter(
     (key) => !key.startsWith(metadataPrefix) && key !== "__id__"
   );
@@ -305,15 +312,20 @@ export const mapBulkQueryResponseGrpcToChalk = <
   TFeatureMap,
   TOutput extends keyof TFeatureMap
 >(
-  response: OnlineQueryBulkResponse
+  response: OnlineQueryBulkResponse,
+  parseOptions: Pick<ChalkClientConfig, "timestampFormat">
 ): ChalkOnlineBulkQueryResponse<TFeatureMap, TOutput> => {
-  const rawData = tableFromIPC(response.scalarsData).toArray();
+  const table = processArrowTable(
+    tableFromIPC(response.scalarsData),
+    parseOptions
+  );
+  const rawData = table.toArray()[0] ?? {};
   const features = new Set(
     Object.keys(rawData[0] ?? {}).filter(
       (key) => !key.startsWith(metadataPrefix) && key !== "__id__"
     )
   ) as Set<string>;
-  const data = rawData.map((datum) =>
+  const data = rawData.map((datum: Record<string, unknown>) =>
     Object.fromEntries(
       Object.entries(datum).filter(([key]) => features.has(key))
     )


### PR DESCRIPTION
- Fixes the GRPC Client Ignoring the `TimestampFormat` option passed in
- Adds a migration guide for the gRPC client into the README, and also updates missing options and diverged docstrings