### PR TITLE
Use primary environment from query server exchange

### DIFF
--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -1,5 +1,6 @@
 import { Vector, DataType } from "apache-arrow";
 import { ChalkClient } from "../_client_http";
+import { ChalkGRPCClient } from "../_client_grpc";
 
 interface IntegrationTestFeatures {
   "all_types.id": number;
@@ -179,6 +180,53 @@ maybe("integration tests (http)", () => {
           outputs: ["all_types.id"],
         });
         expect(result.data["all_types.id"].value).toBe("injected!");
+      },
+      INTEGRATION_TEST_TIMEOUT
+    );
+  });
+
+  describe("automatic query server detection", () => {
+    it(
+      "query all_types.int_feat with no set active environment (uses credential exchange)",
+      async () => {
+        client = new ChalkClient<IntegrationTestFeatures>({
+          clientId: process.env._INTEGRATION_TEST_CLIENT_ID,
+          clientSecret: process.env._INTEGRATION_TEST_CLIENT_SECRET,
+          apiServer: process.env._INTEGRATION_TEST_API_SERVER,
+        });
+
+        const result = await client.query({
+          inputs: {
+            "all_types.id": 1,
+          },
+          outputs: ["all_types.int_feat"],
+        });
+
+        expect(Number(result.data["all_types.int_feat"].value)).toBe(1);
+      },
+      INTEGRATION_TEST_TIMEOUT
+    );
+
+    it(
+      "query all_types.int_feat with no set active environment (uses environment variables)",
+      async () => {
+        process.env._CHALK_ACTIVE_ENVIRONMENT =
+          process.env._INTEGRATION_TEST_ACTIVE_ENVIRONMENT;
+        client = new ChalkClient<IntegrationTestFeatures>({
+          clientId: process.env._INTEGRATION_TEST_CLIENT_ID,
+          clientSecret: process.env._INTEGRATION_TEST_CLIENT_SECRET,
+          apiServer: process.env._INTEGRATION_TEST_API_SERVER,
+        });
+
+        const result = await client.query({
+          inputs: {
+            "all_types.id": 1,
+          },
+          outputs: ["all_types.int_feat"],
+        });
+
+        expect(Number(result.data["all_types.int_feat"].value)).toBe(1);
+        process.env._CHALK_ACTIVE_ENVIRONMENT = undefined;
       },
       INTEGRATION_TEST_TIMEOUT
     );

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -1,6 +1,5 @@
 import { Vector, DataType } from "apache-arrow";
 import { ChalkClient } from "../_client_http";
-import { ChalkGRPCClient } from "../_client_grpc";
 
 interface IntegrationTestFeatures {
   "all_types.id": number;

--- a/src/__test__/integrationGrpc.test.ts
+++ b/src/__test__/integrationGrpc.test.ts
@@ -105,6 +105,53 @@ maybe("integration tests (gRPC)", () => {
     );
   });
 
+  describe("automatic query server detection", () => {
+    it(
+      "query all_types.int_feat with no set active environment (uses credential exchange)",
+      async () => {
+        client = new ChalkGRPCClient<IntegrationTestFeatures>({
+          clientId: process.env._INTEGRATION_TEST_CLIENT_ID,
+          clientSecret: process.env._INTEGRATION_TEST_CLIENT_SECRET,
+          apiServer: process.env._INTEGRATION_TEST_API_SERVER,
+        });
+
+        const result = await client.query({
+          inputs: {
+            "all_types.id": 1,
+          },
+          outputs: ["all_types.int_feat"],
+        });
+
+        expect(Number(result.data["all_types.int_feat"].value)).toBe(1);
+      },
+      INTEGRATION_TEST_TIMEOUT
+    );
+
+    it(
+      "query all_types.int_feat with no set active environment (uses environment variables)",
+      async () => {
+        process.env._CHALK_ACTIVE_ENVIRONMENT =
+          process.env._INTEGRATION_TEST_ACTIVE_ENVIRONMENT;
+        client = new ChalkGRPCClient<IntegrationTestFeatures>({
+          clientId: process.env._INTEGRATION_TEST_CLIENT_ID,
+          clientSecret: process.env._INTEGRATION_TEST_CLIENT_SECRET,
+          apiServer: process.env._INTEGRATION_TEST_API_SERVER,
+        });
+
+        const result = await client.query({
+          inputs: {
+            "all_types.id": 1,
+          },
+          outputs: ["all_types.int_feat"],
+        });
+
+        expect(Number(result.data["all_types.int_feat"].value)).toBe(1);
+        process.env._CHALK_ACTIVE_ENVIRONMENT = undefined;
+      },
+      INTEGRATION_TEST_TIMEOUT
+    );
+  });
+
   describe("query integration_tests", () => {
     it(
       "query all_types.int_feat",

--- a/src/_services/_credentials.ts
+++ b/src/_services/_credentials.ts
@@ -20,7 +20,7 @@ export class CredentialsHolder {
     private http: ChalkHTTPService
   ) {}
 
-  async get() {
+  async get(): Promise<ClientCredentials> {
     if (this.credentials == null) {
       try {
         this.credentials = await this.http.v1_oauth_token({
@@ -52,13 +52,22 @@ export class CredentialsHolder {
     this.credentials = null;
   }
 
+  async getPrimaryEnvironmentFromCredentials(): Promise<
+    string | null | undefined
+  > {
+    const { primary_environment: environmentIdFromCredentials } =
+      await this.get();
+
+    return environmentIdFromCredentials;
+  }
+
   async getEngineUrlFromCredentials(
     environmentId: string | null | undefined
   ): Promise<string | null> {
-    const { engines, primary_environment: environmentIdFromCredentials } =
-      await this.get();
-    const envIdToUse = environmentId || environmentIdFromCredentials;
-    const engineForEnvironment = envIdToUse ? engines?.[envIdToUse] : null;
+    const { engines } = await this.get();
+    const engineForEnvironment = environmentId
+      ? engines?.[environmentId]
+      : null;
 
     return engineForEnvironment || null;
   }


### PR DESCRIPTION
Use the environment from query server exchange more comprehensively, where it was missing from the env ID header (used for routing)