### PR TITLE
Fix issue where include_meta was not piped to online bulk query gRPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,12 @@ Query Server in your Chalk Environment, changing to the gRPC Client can be done 
 - Check to see if any of the following initialization options need to be changed:
   - The option `useQueryServerFromCredentialExchange` has been changed to `skipQueryServerFromCredentialExchange` 
     and *negated* to better reflect the default behavior for the gRPC Query Server.
-  - It is most likely not necessary to change a provided `QueryServer` as most routing is done via SDK-set headers, but 
-    depending on your setup this may need to be directly specified if using a non-standard port - the gRPC query server listens
-    on port `443` by default.
+  - Check your Chalk Environment for any custom routing rules. If you are not sure, reach out to Chalk support for help here.
+    - If your previous SDK client explicitly sets the `engine-type: engine` header on requests, this will need to be changed 
+      to `engine-grpc` (or omitted, the gRPC client will automatically set this header but respects all overrides).
+    - It is most likely not necessary to change a provided `QueryServer` as most routing is done via SDK-set headers, but 
+      depending on your setup this may need to be directly specified if using a non-standard port - the gRPC query server listens
+      on port `443` by default.
   - It is **not** necessary to remove the `fetch` or `fetchHeaders` as these are still used during some HTTP routines
     such as fetching credentials.
 

--- a/src/_client_grpc.ts
+++ b/src/_client_grpc.ts
@@ -54,6 +54,7 @@ export class ChalkGRPCClient<TFeatureMap = Record<string, ChalkScalar>>
 
   async getQueryService(opts?: ChalkGRPCClientOpts): Promise<ChalkGRPCService> {
     const queryEndpoint = await this.getQueryServer();
+    console.log(`query endpoint: ${queryEndpoint}`);
     return new ChalkGRPCService({
       additionalHeaders: opts?.additionalHeaders,
       endpoint: queryEndpoint,

--- a/src/_client_http.ts
+++ b/src/_client_http.ts
@@ -208,6 +208,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       context: {
         tags: request.scopeTags,
       },
+      include_meta: request.include_meta,
       query_context: request.queryContext,
       correlation_id: request.correlationId,
       deployment_id: request.previewDeploymentId,

--- a/src/_client_http.ts
+++ b/src/_client_http.ts
@@ -123,6 +123,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
         context: {
           tags: request.scopeTags,
         },
+        explain: request.explain,
         query_context: request.queryContext,
         correlation_id: request.correlationId,
         deployment_id: request.previewDeploymentId,
@@ -208,6 +209,7 @@ export class ChalkClient<TFeatureMap = Record<string, ChalkScalar>>
       context: {
         tags: request.scopeTags,
       },
+      explain: request.explain,
       include_meta: request.include_meta,
       query_context: request.queryContext,
       correlation_id: request.correlationId,

--- a/src/_feather.ts
+++ b/src/_feather.ts
@@ -11,6 +11,7 @@ export interface IntermediateRequestBodyJSON<
   context?: {
     tags?: string[];
   };
+  explain?: boolean;
   include_meta?: boolean;
   query_context?: {
     [key: string]: string | number | boolean;

--- a/src/_feather.ts
+++ b/src/_feather.ts
@@ -11,6 +11,7 @@ export interface IntermediateRequestBodyJSON<
   context?: {
     tags?: string[];
   };
+  include_meta?: boolean;
   query_context?: {
     [key: string]: string | number | boolean;
   };

--- a/src/_interface/index.ts
+++ b/src/_interface/index.ts
@@ -54,6 +54,9 @@ export interface ChalkOnlineQueryRequest<
     [K in keyof TFeatureMap]?: string;
   };
 
+  // If true, will populate an explain output that includes performance and operations metadata.
+  explain?: boolean;
+
   scopeTags?: string[];
 
   // If specified, Chalk will route your request to the relevant preview deployment.
@@ -231,6 +234,7 @@ export interface ChalkOnlineBulkQueryRequest<
 > {
   inputs: Partial<{ [K in keyof TFeatureMap]: TFeatureMap[K][] }>;
   outputs: TOutput[];
+  explain?: boolean;
   staleness?: {
     [K in keyof TFeatureMap]?: string;
   };

--- a/src/_interface/index.ts
+++ b/src/_interface/index.ts
@@ -237,6 +237,7 @@ export interface ChalkOnlineBulkQueryRequest<
   scopeTags?: string[];
   previewDeploymentId?: string;
   correlationId?: string;
+  include_meta?: boolean;
   queryName?: string;
   queryNameVersion?: string;
   queryMeta?: {

--- a/src/_services/_http.ts
+++ b/src/_services/_http.ts
@@ -320,6 +320,7 @@ export class ChalkHTTPService {
       };
       deployment_id?: string;
       correlation_id?: string;
+      explain?: boolean;
       query_name?: string;
       query_name_version?: string;
       meta?: {

--- a/src/_utils/_grpc.ts
+++ b/src/_utils/_grpc.ts
@@ -73,7 +73,7 @@ export const mapOnlineBulkQueryRequestChalkToGRPC = <
                 request.encodingOptions.encodeStructsAsObjects,
             }
           : undefined,
-      includeMeta: !!request,
+      includeMeta: !!request.include_meta,
       metadata: request.queryMeta ?? {},
       // TODO Add option before merge
       explain: true,

--- a/src/_utils/_grpc.ts
+++ b/src/_utils/_grpc.ts
@@ -75,8 +75,7 @@ export const mapOnlineBulkQueryRequestChalkToGRPC = <
           : undefined,
       includeMeta: !!request.include_meta,
       metadata: request.queryMeta ?? {},
-      // TODO Add option before merge
-      explain: true,
+      explain: request.explain,
     },
     now: new Array(inputLength).fill(safeNow),
     staleness: (request.staleness as Record<string, string>) ?? {},


### PR DESCRIPTION
Fixes two issues: 
- includeMeta was written as `!!request` instead of `!!request.include_meta`
- `request.include_meta` was included in the online query request but not the online bulk query request