### PR TITLE
fix issue where explain:false is encoded poorly

### DIFF
--- a/src/_utils/_grpc.ts
+++ b/src/_utils/_grpc.ts
@@ -75,7 +75,8 @@ export const mapOnlineBulkQueryRequestChalkToGRPC = <
           : undefined,
       includeMeta: !!request.include_meta,
       metadata: request.queryMeta ?? {},
-      explain: request.explain,
+      // note: serializing is a little messed up, false will encode poorly.
+      explain: request.explain || undefined,
     },
     now: new Array(inputLength).fill(safeNow),
     staleness: (request.staleness as Record<string, string>) ?? {},


### PR DESCRIPTION
Fix issue where `explain: false` does not work for gRPC in the intended way  - reading the pb encoding, this only encodes correctly when undefined is explicitly passed in.