### PR TITLE
Infer Struct Shape from first non-null element

### DIFF
--- a/src/__test__/arrow.test.ts
+++ b/src/__test__/arrow.test.ts
@@ -1,11 +1,9 @@
 import {
-  DataType,
   LargeUtf8,
   Int32,
   Int64,
   Bool,
   List,
-  Field,
   Struct,
   Float64,
   Table,
@@ -126,6 +124,17 @@ describe("inferElementType", () => {
       expect(structType.children[0].type).toBeInstanceOf(Struct);
       expect(structType.children[1].name).toBe("count");
       expect(structType.children[1].type).toBeInstanceOf(Int32);
+    });
+
+    test("should return Struct even when fields are null", () => {
+      const result = inferElementType({ mineral: "Talc", hardness: null });
+      expect(result).toBeInstanceOf(Struct);
+      const structType = result as Struct;
+      expect(structType.children).toHaveLength(2);
+      expect(structType.children[0].name).toBe("mineral");
+      expect(structType.children[0].type).toBeInstanceOf(LargeUtf8);
+      expect(structType.children[1].name).toBe("hardness");
+      expect(structType.children[1].type).toBeInstanceOf(LargeUtf8);
     });
 
     test("should handle list of structs", () => {

--- a/src/__test__/arrow.test.ts
+++ b/src/__test__/arrow.test.ts
@@ -1,0 +1,249 @@
+import {
+  DataType,
+  LargeUtf8,
+  Int32,
+  Int64,
+  Bool,
+  List,
+  Field,
+  Struct,
+  Float64,
+  Table,
+} from "apache-arrow";
+import { inferElementType, tableFromArraysTyped } from "../_utils/_arrow";
+
+describe("inferElementType", () => {
+  describe("primitive types", () => {
+    test("should return LargeUtf8 for null", () => {
+      const result = inferElementType(null);
+      expect(result).toBeInstanceOf(LargeUtf8);
+    });
+
+    test("should return LargeUtf8 for undefined", () => {
+      const result = inferElementType(undefined);
+      expect(result).toBeInstanceOf(LargeUtf8);
+    });
+
+    test("should return LargeUtf8 for string", () => {
+      const result = inferElementType("hello");
+      expect(result).toBeInstanceOf(LargeUtf8);
+    });
+
+    test("should return Bool for boolean", () => {
+      const result = inferElementType(true);
+      expect(result).toBeInstanceOf(Bool);
+    });
+
+    test("should return Float64 for decimal number", () => {
+      const result = inferElementType(3.14);
+      expect(result).toBeInstanceOf(Float64);
+    });
+
+    test("should return Int32 for small integer", () => {
+      const result = inferElementType(42);
+      expect(result).toBeInstanceOf(Int32);
+    });
+
+    test("should return Int32 for max Int32 value", () => {
+      const result = inferElementType(2147483647);
+      expect(result).toBeInstanceOf(Int32);
+    });
+
+    test("should return Int32 for min Int32 value", () => {
+      const result = inferElementType(-2147483648);
+      expect(result).toBeInstanceOf(Int32);
+    });
+
+    test("should return Int64 for large positive integer", () => {
+      const result = inferElementType(2147483648);
+      expect(result).toBeInstanceOf(Int64);
+    });
+
+    test("should return Int64 for large negative integer", () => {
+      const result = inferElementType(-2147483649);
+      expect(result).toBeInstanceOf(Int64);
+    });
+  });
+
+  describe("array types", () => {
+    test("should return List of LargeUtf8 for string array", () => {
+      const result = inferElementType(["a", "b", "c"]);
+      expect(result).toBeInstanceOf(List);
+      const listType = result as List;
+      expect(listType.children[0].type).toBeInstanceOf(LargeUtf8);
+    });
+
+    test("should return List of Int32 for integer array", () => {
+      const result = inferElementType([1, 2, 3]);
+      expect(result).toBeInstanceOf(List);
+      const listType = result as List;
+      expect(listType.children[0].type).toBeInstanceOf(Int32);
+    });
+
+    test("should return List of Bool for boolean array", () => {
+      const result = inferElementType([true, false, true]);
+      expect(result).toBeInstanceOf(List);
+      const listType = result as List;
+      expect(listType.children[0].type).toBeInstanceOf(Bool);
+    });
+
+    test("should handle array with null elements", () => {
+      const result = inferElementType([null, "hello", null]);
+      expect(result).toBeInstanceOf(List);
+      const listType = result as List;
+      expect(listType.children[0].type).toBeInstanceOf(LargeUtf8);
+    });
+
+    test("should handle empty array", () => {
+      const result = inferElementType([]);
+      expect(result).toBeInstanceOf(List);
+      const listType = result as List;
+      expect(listType.children[0].type).toBeInstanceOf(LargeUtf8);
+    });
+  });
+
+  describe("object types", () => {
+    test("should return Struct for simple object", () => {
+      const result = inferElementType({ mineral: "Quartz", hardness: 7 });
+      expect(result).toBeInstanceOf(Struct);
+      const structType = result as Struct;
+      expect(structType.children).toHaveLength(2);
+      expect(structType.children[0].name).toBe("mineral");
+      expect(structType.children[0].type).toBeInstanceOf(LargeUtf8);
+      expect(structType.children[1].name).toBe("hardness");
+      expect(structType.children[1].type).toBeInstanceOf(Int32);
+    });
+
+    test("should return Struct for nested object", () => {
+      const result = inferElementType({
+        specimen: { mineral: "Pyrite", lustrous: true },
+        count: 42,
+      });
+      expect(result).toBeInstanceOf(Struct);
+      const structType = result as Struct;
+      expect(structType.children).toHaveLength(2);
+      expect(structType.children[0].name).toBe("specimen");
+      expect(structType.children[0].type).toBeInstanceOf(Struct);
+      expect(structType.children[1].name).toBe("count");
+      expect(structType.children[1].type).toBeInstanceOf(Int32);
+    });
+
+    test("should handle list of structs", () => {
+      const result = inferElementType([
+        { id: 1, mineral: "Anthracite" },
+        { id: 2, mineral: "Beryl" },
+      ]);
+      expect(result).toBeInstanceOf(List);
+      const listType = result as List;
+      expect(listType.children[0].type).toBeInstanceOf(Struct);
+      const structType = listType.children[0].type as Struct;
+      expect(structType.children).toHaveLength(2);
+      expect(structType.children[0].name).toBe("id");
+      expect(structType.children[0].type).toBeInstanceOf(Int32);
+      expect(structType.children[1].name).toBe("mineral");
+      expect(structType.children[1].type).toBeInstanceOf(LargeUtf8);
+    });
+  });
+
+  test("should return LargeUtf8 as fallback for unknown types", () => {
+    const result = inferElementType(Symbol("test"));
+    expect(result).toBeInstanceOf(LargeUtf8);
+  });
+});
+
+describe("tableFromArraysTyped", () => {
+  test("should create table from simple inputs", () => {
+    const inputs = {
+      minerals: ["Anthracite", "Beryl", "Calcite"],
+      hardness: [2, 7.5, 3],
+      gemstone: [false, true, false],
+    };
+
+    const table = tableFromArraysTyped(inputs);
+    expect(table).toBeInstanceOf(Table);
+    expect(table.numCols).toBe(3);
+    expect(table.numRows).toBe(3);
+    expect(table.schema.fields.map((f) => f.name)).toEqual([
+      "minerals",
+      "hardness",
+      "gemstone",
+    ]);
+  });
+
+  test("should handle empty arrays", () => {
+    const inputs = {
+      empty: [],
+      minerals: ["Anthracite"],
+    };
+
+    const table = tableFromArraysTyped(inputs);
+    expect(table).toBeInstanceOf(Table);
+    expect(table.numCols).toBe(2);
+  });
+
+  test("should handle arrays with null values", () => {
+    const inputs = {
+      minerals: [null, "Beryl", null],
+      hardness: [null, 7.5, 4],
+    };
+
+    const table = tableFromArraysTyped(inputs);
+    expect(table).toBeInstanceOf(Table);
+    expect(table.numCols).toBe(2);
+    expect(table.numRows).toBe(3);
+  });
+
+  test("should handle arrays with all null values", () => {
+    const inputs = {
+      nulls: [null, null, null],
+      minerals: ["Anthracite", "Beryl", "Calcite"],
+    };
+
+    const table = tableFromArraysTyped(inputs);
+    expect(table).toBeInstanceOf(Table);
+    expect(table.numCols).toBe(2);
+    expect(table.numRows).toBe(3);
+  });
+
+  test("should handle complex nested data", () => {
+    const inputs = {
+      specimens: [
+        { id: 1, mineral: "Anthracite", properties: ["carbon", "fuel"] },
+        { id: 2, mineral: "Beryl", properties: ["gemstone"] },
+      ],
+      geology: [
+        { formation: "Metamorphic", age: 300.5 },
+        { formation: "Igneous", age: 200.0 },
+      ],
+    };
+
+    const table = tableFromArraysTyped(inputs);
+    expect(table).toBeInstanceOf(Table);
+    expect(table.numCols).toBe(2);
+    expect(table.numRows).toBe(2);
+  });
+
+  test("should handle list of structs", () => {
+    const inputs = {
+      minerals: [
+        [
+          { id: 1, name: "Anthracite", classification: "Organic" },
+          { id: 2, name: "Beryl", classification: "Silicate" },
+          { id: 3, name: "Calcite", classification: "Carbonate" },
+        ],
+      ],
+    };
+
+    const table = tableFromArraysTyped(inputs);
+    expect(table).toBeInstanceOf(Table);
+    expect(table.numCols).toBe(1);
+    expect(table.numRows).toBe(1);
+
+    const mineralsColumn = table.getChild("minerals");
+    expect(mineralsColumn).toBeDefined();
+    expect(mineralsColumn!.type).toBeInstanceOf(List);
+
+    const listType = mineralsColumn!.type as List;
+    expect(listType.children[0].type).toBeInstanceOf(Struct);
+  });
+});

--- a/src/__test__/serialization.test.ts
+++ b/src/__test__/serialization.test.ts
@@ -6,7 +6,7 @@ import {
   featherRequestHeaderFromBody,
   IntermediateRequestBodyJSON,
   serializeMultipleQueryInputFeather,
-} from "../_feather";
+} from "../_utils/_feather";
 
 describe("featherRequestHeaderFromBody", () => {
   const body1: IntermediateRequestBodyJSON<

--- a/src/_client_http.ts
+++ b/src/_client_http.ts
@@ -3,7 +3,7 @@ import { ChalkError } from "./_errors";
 import {
   IntermediateRequestBodyJSON,
   serializeMultipleQueryInputFeather,
-} from "./_feather";
+} from "./_utils/_feather";
 import { ChalkHTTPService } from "./_services/_http";
 import { ChalkHttpHeaders, ChalkHttpHeadersStrict } from "./_interface/_header";
 import { CredentialsHolder } from "./_services/_credentials";

--- a/src/_utils/_arrow.ts
+++ b/src/_utils/_arrow.ts
@@ -48,7 +48,10 @@ export const inferElementType = (element: unknown): DataType => {
 };
 
 /**
- * An improvement
+ * An improvement over the original arrow logic to construct a table from a map of arrays.
+ * This one will check the elements for the first non-null element to infer a more complex shape.
+ * Mixed-type (including struct schema) arrays still cannot be parsed though
+ *
  * @param inputs
  */
 export const tableFromArraysTyped = <

--- a/src/_utils/_arrow.ts
+++ b/src/_utils/_arrow.ts
@@ -1,0 +1,76 @@
+import {
+  DataType,
+  LargeUtf8,
+  Int32,
+  Int64,
+  Bool,
+  List,
+  Field,
+  Struct,
+  vectorFromArray,
+  Vector,
+  Table,
+  Float64,
+} from "apache-arrow";
+import { ChalkOnlineBulkQueryRequest } from "../_interface";
+
+export const inferElementType = (element: unknown): DataType => {
+  if (element == null) return new LargeUtf8(); // Default for null values
+
+  if (typeof element === "string") return new LargeUtf8();
+  if (typeof element === "boolean") return new Bool();
+  if (typeof element === "number") {
+    if (Number.isInteger(element)) {
+      return element >= -2147483648 && element <= 2147483647
+        ? new Int32()
+        : new Int64();
+    }
+    return new Float64();
+  }
+  if (Array.isArray(element)) {
+    // For nested arrays, infer type from first non-null element
+    const firstNonNull = element.find((item) => item != null);
+    const childType = inferElementType(firstNonNull);
+    return new List(new Field("item", childType));
+  }
+  if (typeof element === "object") {
+    // For objects, create struct type from keys
+    const structFields = Object.keys(element).map((key) => {
+      const fieldType = inferElementType(
+        (element as Record<string, unknown>)[key]
+      );
+      return new Field(key, fieldType);
+    });
+    return new Struct(structFields);
+  }
+
+  return new LargeUtf8(); // Default fallback
+};
+
+/**
+ * An improvement
+ * @param inputs
+ */
+export const tableFromArraysTyped = <
+  TFeatureMap,
+  TOutput extends keyof TFeatureMap
+>(
+  inputs: ChalkOnlineBulkQueryRequest<TFeatureMap, TOutput>["inputs"]
+): Table => {
+  const entries = Object.entries(inputs) as [string, unknown[]][];
+  const vectorMap: Record<string, Vector> = {};
+  for (const [key, col] of entries) {
+    const firstNonNullElement = col.find((element) => element != null);
+    if (col.length === 0 || firstNonNullElement == null) {
+      vectorMap[key] = vectorFromArray(col);
+      continue;
+    }
+
+    vectorMap[key] = vectorFromArray(
+      col,
+      inferElementType(firstNonNullElement)
+    );
+  }
+
+  return new Table(vectorMap);
+};

--- a/src/_utils/_feather.ts
+++ b/src/_utils/_feather.ts
@@ -1,21 +1,7 @@
-import {
-  Table,
-  Vector,
-  tableFromArrays,
-  tableToIPC,
-  vectorFromArray,
-  List,
-  Struct,
-  LargeUtf8,
-  Field,
-  DataType,
-  Float64,
-  Bool,
-  Int32,
-  Int64,
-} from "apache-arrow";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
 import { MULTI_QUERY_MAGIC_STR } from "../_bulk_response";
 import { ChalkOnlineBulkQueryRequest } from "../_interface";
+import { tableFromArraysTyped } from "./_arrow";
 
 export interface IntermediateRequestBodyJSON<
   TFeatureMap,
@@ -75,58 +61,6 @@ export function featherRequestHeaderFromBody<
     client_supports_64bit: false,
     client_supported_64bit_types: ["Int64", "LargeBinary"],
   };
-}
-
-function inferElementType(element: unknown): DataType {
-  if (element == null) return new LargeUtf8(); // Default for null values
-
-  if (typeof element === "string") return new LargeUtf8();
-  if (typeof element === "boolean") return new Bool();
-  if (typeof element === "number") {
-    if (Number.isInteger(element)) {
-      return element >= -2147483648 && element <= 2147483647
-        ? new Int32()
-        : new Int64();
-    }
-    return new Float64();
-  }
-  if (Array.isArray(element)) {
-    // For nested arrays, infer type from first non-null element
-    const firstNonNull = element.find((item) => item != null);
-    const childType = inferElementType(firstNonNull);
-    return new List(new Field("item", childType));
-  }
-  if (typeof element === "object") {
-    // For objects, create struct type from keys
-    const structFields = Object.keys(element).map((key) => {
-      const fieldType = inferElementType(
-        (element as Record<string, unknown>)[key]
-      );
-      return new Field(key, fieldType);
-    });
-    return new Struct(structFields);
-  }
-
-  return new LargeUtf8(); // Default fallback
-}
-
-export function tableFromArraysTyped<
-  TFeatureMap,
-  TOutput extends keyof TFeatureMap
->(inputs: ChalkOnlineBulkQueryRequest<TFeatureMap, TOutput>["inputs"]): Table {
-  const entries = Object.entries(inputs) as [string, unknown[]][];
-  const vectorMap: Record<string, Vector> = {};
-  for (const [key, col] of entries) {
-    const firstElement = col.at(0);
-    if (col.length === 0 || firstElement == null) {
-      vectorMap[key] = vectorFromArray(col);
-      continue;
-    }
-
-    vectorMap[key] = vectorFromArray(col, inferElementType(firstElement));
-  }
-
-  return new Table(vectorMap);
 }
 
 export function serializeBulkQueryInputFeather<

--- a/src/_utils/_grpc.ts
+++ b/src/_utils/_grpc.ts
@@ -18,7 +18,7 @@ import {
   ChalkQueryMeta,
 } from "../_interface";
 import { ChalkHttpHeaders } from "../_interface/_header";
-import { serializeBulkQueryInputFeather } from "../_feather";
+import { serializeBulkQueryInputFeather } from "./_feather";
 import {
   FeatherBodyType,
   GenericSingleQuery,


### PR DESCRIPTION
For more complex structs, arrow has trouble serializing them. This creates the `arrowTableTyped` that uses the first non-null element's fields and constructs a typed vector from it