### PR TITLE
Add PingQueryServer to the gRPC callable interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 node_modules/
 
 *.log
+
+.claude/

--- a/src/__test__/integrationGrpc.test.ts
+++ b/src/__test__/integrationGrpc.test.ts
@@ -152,6 +152,25 @@ maybe("integration tests (gRPC)", () => {
     );
   });
 
+  describe("ping integration_tests", () => {
+    it("can ping the query server", async () => {
+      const response = await client.pingQueryServer();
+      expect(response.success).toBe(true);
+    });
+
+    it("will fail with bad configuration", async () => {
+      client = new ChalkGRPCClient<IntegrationTestFeatures>({
+        clientId: process.env._INTEGRATION_TEST_CLIENT_ID,
+        clientSecret: process.env._INTEGRATION_TEST_CLIENT_SECRET,
+        apiServer: process.env._INTEGRATION_TEST_API_SERVER,
+        queryServer: "not_a_real_query_server",
+      });
+
+      const response = await client.pingQueryServer();
+      expect(response.success).toBe(false);
+    });
+  });
+
   describe("query integration_tests", () => {
     it(
       "query all_types.int_feat",

--- a/src/_interface/_client.ts
+++ b/src/_interface/_client.ts
@@ -7,6 +7,7 @@ import {
   ChalkOnlineMultiQueryResponse,
   ChalkOnlineQueryRequest,
   ChalkOnlineQueryResponse,
+  ChalkPingQueryServerResponse,
   ChalkTriggerResolverRunRequest,
   ChalkTriggerResolverRunResponse,
   ChalkUploadSingleRequest,
@@ -101,4 +102,14 @@ export interface ChalkClientHTTPInterface<
    * Useful as a sanity test of your configuration.
    */
   whoami(): Promise<ChalkWhoamiResponse>;
+}
+
+export interface ChalkClientGRPCInterface<
+  TFeatureMap = Record<string, ChalkScalar>
+> extends ChalkClientInterface<TFeatureMap> {
+  /**
+   * Checks to make sure that the query server is reachable from this client with the given configurations
+   * and credentials.
+   */
+  pingQueryServer(): Promise<ChalkPingQueryServerResponse>;
 }

--- a/src/_interface/index.ts
+++ b/src/_interface/index.ts
@@ -1,4 +1,7 @@
+import { ChalkError } from "../_errors";
+
 export type {
+  ChalkClientGRPCInterface,
   ChalkClientHTTPInterface,
   ChalkClientInterface,
   ChalkClientConfig,
@@ -290,4 +293,9 @@ export interface ChalkTriggerResolverRunResponse {
 export interface ChalkWhoamiResponse {
   // The id of the user.
   user: string;
+}
+
+export interface ChalkPingQueryServerResponse {
+  success?: boolean;
+  error?: ChalkError;
 }

--- a/src/_services/_grpc.ts
+++ b/src/_services/_grpc.ts
@@ -20,6 +20,10 @@ import {
   OnlineQueryMultiRequest,
   OnlineQueryMultiResponse,
 } from "../gen/proto/chalk/common/v1/online_query.pb";
+import {
+  PingRequest,
+  PingResponse,
+} from "../gen/proto/chalk/engine/v1/query_server.pb";
 import { USER_AGENT } from "../_user_agent";
 import { ChalkRequestOptions } from "../_interface/_request";
 
@@ -138,5 +142,13 @@ export class ChalkGRPCService {
       OnlineQueryMultiRequest,
       OnlineQueryMultiResponse
     >((...callArgs) => this.queryClient.onlineQueryMulti(...callArgs))(...args);
+  };
+
+  public pingQueryServer = (
+    ...args: GRPCCallArgs<PingRequest>
+  ): Promise<PingResponse> => {
+    return this.promisfyGRPCCall<PingRequest, PingResponse>((...callArgs) =>
+      this.queryClient.ping(...callArgs)
+    )(...args);
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { ChalkError, isChalkError } from "./_errors";
 export { ChalkHttpHeaders } from "./_interface/_header";
 export {
   ChalkClientInterface,
+  ChalkClientGRPCInterface,
+  ChalkClientHTTPInterface,
   ChalkErrorData,
   ChalkGetRunStatusResponse,
   ChalkOnlineQueryRequest,


### PR DESCRIPTION
Adds a `PingQueryServer`, the first divergence between the two clients

Adds tests :) 